### PR TITLE
Allow to return immediatly from queue.take() if there are no ready tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ take the highest-priority task.
 Otherwise, wait for a `ready` task to appear in the queue, and, as
 soon as it appears, mark it as `taken` and return to the consumer.
 If there is a `timeout`, and the task doesn't appear until the
-timeout expires, return 'nil'. If timeout is not given, wait
-indefinitely until a task appears.
+timeout expires, return 'nil' (a timeout of 0 returns immediately).
+If timeout is not given or negative, wait indefinitely until a task
+appears.
 
 All the time while the consumer is working on a task, it must keep
 the connection to the server open. If a connection disappears while

--- a/init.lua
+++ b/init.lua
@@ -754,12 +754,9 @@ queue.take = function(space, tube, timeout)
     space = tonumber(space)
 
     if timeout == nil then
-        timeout = 0
+        timeout = -1
     else
         timeout = tonumber(timeout)
-        if timeout < 0 then
-            timeout = 0
-        end
     end
 
     local created = box.time()
@@ -806,8 +803,13 @@ queue.take = function(space, tube, timeout)
             return rettask(task)
         end
 
+        if timeout == 0 then
+            queue.stat[space][tube]:inc('take_timeout')
+            return
+        end
+
         if timeout > 0 then
-            now = box.time()
+            local now = box.time()
             if now < created + timeout then
                 queue.consumers[space][tube]:get(created + timeout - now)
             else


### PR DESCRIPTION
```
queue.take(0, 'q')     -- waits indefinitely
queue.take(0, 'q', -1) -- waits indefinitely
queue.take(0, 'q', 0)  -- returns immediately
queue.take(0, 'q', 1)  -- waits 1 second and returns
```