### PR TITLE
avoid unneeded :transform in tube.delete

### DIFF
--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -190,8 +190,7 @@ end
 
 function tube.delete(self, id)
     self:peek(id)
-    return self.raw:normalize_task(
-        self.raw:delete(id):transform(2, 1, state.DONE))
+    return self.raw:normalize_task(self.raw:delete(id))
 end
 
 -- drop tube


### PR DESCRIPTION
All the queue drivers do `:transform(2, 1, state.DONE)` before returning the task from their `.delete` method.