### PR TITLE
fix: avoid calling on_task_change with nil

### DIFF
--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -283,9 +283,6 @@ local function make_self(driver, space, tube_name, tube_type, tube_id, opts)
     local on_task_change = function(task, stats_data)
         self.on_task_change_cb(task, stats_data)
 
-        -- task was removed
-        if task == nil then return end
-
         local queue_consumers = box.space._queue_consumers
         local queue_taken     = box.space._queue_taken
 
@@ -294,7 +291,7 @@ local function make_self(driver, space, tube_name, tube_type, tube_id, opts)
         if taken ~= nil then
             queue_taken:delete{taken[1], taken[2], taken[3]}
         end
-        -- task swicthed to ready (or new task)
+        -- task switched to ready (or new task)
         if task[2] == state.READY then
             local tube_id = self.tube_id
             local consumer = queue_consumers.index.consumer:min{tube_id}
@@ -308,7 +305,7 @@ local function make_self(driver, space, tube_name, tube_type, tube_id, opts)
                     end
                 end
             end
-        -- task swicthed to taken - registry in taken space
+        -- task switched to taken - register in taken space
         elseif task[2] == state.TAKEN then
             queue_taken:insert{session.id(), self.tube_id, task[1], fiber.time64()}
         end

--- a/queue/abstract/driver/fifo.lua
+++ b/queue/abstract/driver/fifo.lua
@@ -78,8 +78,8 @@ function method.delete(self, id)
     self.space:delete(id)
     if task ~= nil then
         task = task:transform(2, 1, state.DONE)
+        self.on_task_change(task, 'delete')
     end
-    self.on_task_change(task, 'delete')
     return task
 end
 

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -294,8 +294,8 @@ function method.delete(self, id)
     self.space:delete(id)
     if task ~= nil then
         task = task:transform(2, 1, state.DONE)
+        self:on_task_change(task, 'delete')
     end
-    self:on_task_change(task, 'delete')
     return task
 end
 

--- a/queue/abstract/driver/utube.lua
+++ b/queue/abstract/driver/utube.lua
@@ -93,14 +93,12 @@ function method.delete(self, id)
     self.space:delete(id)
     if task ~= nil then
         task = task:transform(2, 1, state.DONE)
+        self.on_task_change(task, 'delete')
 
         local neighbour = self.space.index.utube:min{state.READY, task[3]}
-        self.on_task_change(task, 'delete')
         if neighbour then
             self.on_task_change(neighbour)
         end
-    else
-        self.on_task_change(task, 'delete')
     end
     return task
 end

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -309,7 +309,6 @@ function method.delete(self, id)
         task = task:transform(i_status, 1, state.DONE)
         return process_neighbour(self, task, 'delete')
     end
-    self:on_task_change(task, 'delete')
 end
 
 -- release task


### PR DESCRIPTION
This fixes #74 

Correct me if I'm wrong, but when `self.space:get(id)` returns nil, that means the task has already been deleted or acknowledged, so there's no point in calling `on_task_change(nil, 'delete')`.