### PR TITLE
Fixed Cmake - set proper LUA path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,9 @@ file(GLOB TEST_LIST ${CMAKE_SOURCE_DIR}/t/*.t)
 foreach(TEST ${TEST_LIST})
     get_filename_component(TEST_NAME ${TEST} NAME)
     add_test            (memtx-${TEST_NAME} tarantool ${TEST})
-    set_tests_properties(memtx-${TEST_NAME} PROPERTIES ENVIRONMENT "${LUA_PATH}")
-    set_tests_properties(memtx-${TEST_NAME} PROPERTIES ENVIRONMENT "ENGINE=memtx")
+    set_tests_properties(memtx-${TEST_NAME} PROPERTIES ENVIRONMENT "ENGINE=memtx;${LUA_PATH}")
     add_test            (vinyl-${TEST_NAME} tarantool ${TEST})
-    set_tests_properties(vinyl-${TEST_NAME} PROPERTIES ENVIRONMENT "${LUA_PATH}")
-    set_tests_properties(vinyl-${TEST_NAME} PROPERTIES ENVIRONMENT "ENGINE=vinyl")
+    set_tests_properties(vinyl-${TEST_NAME} PROPERTIES ENVIRONMENT "ENGINE=vinyl;${LUA_PATH}")
 endforeach()
 
 add_custom_target(check


### PR DESCRIPTION
Due to cmake syntax we have to set ENVIROMENT in a single
set_test_properties definition