### PR TITLE
Add Ubuntu Bionic CI target: test and deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=artful
+      - OS=ubuntu DIST=bionic
       - OS=debian DIST=wheezy
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch


### PR DESCRIPTION
Also I switched CI to 1.9 (set `PACKAGECLOUD_REPO` to `1_9`), because `1_7` bucket does not nave tarantool-dev package for Ubuntu Bionic.

Fixes #82.