### PR TITLE
Fix 090 test on MAC

### DIFF
--- a/t/090-grant-check.t
+++ b/t/090-grant-check.t
@@ -58,6 +58,7 @@ test:test('check for space grants', function(test)
     tube:drop()
 end)
 
+_G.queue = nil
 test:test('check for call grants', function(test)
     -- prepare for tests
     _G.queue = require('queue')


### PR DESCRIPTION
Before it failed with error:
2019-03-26 22:52:57.418 [97087] main/101/090-grant-check.t F> ./t/090-grant-check.t:64: assign to undeclared variable 'queue'

Now this test is passed