### PR TITLE
travis-ci: update distros and repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_deploy:
   - ls -l build/
 
 deploy:
+  # Deploy packages to PackageCloud from master branch
   - provider: packagecloud
     username: tarantool
     repository: "1_10"
@@ -72,6 +73,40 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  # Deploy packages to PackageCloud from tags
+  # see:
+  #   * https://github.com/tarantool/tarantool/issues/3745
+  #   * https://github.com/travis-ci/travis-ci/issues/7780#issuecomment-302389370
+  - provider: packagecloud
+    username: tarantool
+    repository: "1_10"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2x"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_2"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb}
+    skip_cleanup: true
+    on:
+      tags: true
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,22 @@ env:
     global:
       - PRODUCT=tarantool-queue
     matrix:
-      - TARGET=test VERSION=1_7
-      - TARGET=test VERSION=1_9
       - TARGET=test VERSION=1_10
       - TARGET=test VERSION=2x
       - TARGET=test VERSION=2_2
       - OS=el DIST=6
       - OS=el DIST=7
-      - OS=fedora DIST=26
-      - OS=fedora DIST=27
       - OS=fedora DIST=28
       - OS=fedora DIST=29
+      - OS=fedora DIST=30
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
       - OS=ubuntu DIST=cosmic
+      - OS=ubuntu DIST=disco
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
+      - OS=debian DIST=buster
 
 script:
   - git describe --long
@@ -44,26 +43,6 @@ before_deploy:
   - ls -l build/
 
 deploy:
-  - provider: packagecloud
-    username: tarantool
-    repository: "1_7"
-    token: ${PACKAGECLOUD_TOKEN}
-    dist: ${OS}/${DIST}
-    package_glob: build/*.{rpm,deb}
-    skip_cleanup: true
-    on:
-      branch: master
-      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
-  - provider: packagecloud
-    username: tarantool
-    repository: "1_9"
-    token: ${PACKAGECLOUD_TOKEN}
-    dist: ${OS}/${DIST}
-    package_glob: build/*.{rpm,deb}
-    skip_cleanup: true
-    on:
-      branch: master
-      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
   - provider: packagecloud
     username: tarantool
     repository: "1_10"


### PR DESCRIPTION
Removed release repos 1_7/1_9.

Added the build distros:
    Fedora 30, Ubuntu 19.04, Debian 10.
Removed the build distros:
    Fedora 26,27.

Closes #94