### PR TITLE
fix fifottl_fiber_iteration error handling

### DIFF
--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -164,7 +164,7 @@ local function fifottl_fiber(self)
     while true do
         if not box.cfg.read_only then
             local stat, err = pcall(fifottl_fiber_iteration, self, processed)
-            if not stat and not err.code == box.error.READONLY then
+            if not stat and not (err.code == box.error.READONLY) then
                 log.error("error catched: %s", tostring(err))
                 log.error("exiting fiber '%s'", fiber.name())
                 return 1


### PR DESCRIPTION
fifottl_fiber pcalls fifottl_fiber_iteration and then handles
result. Returned error code comparison with box.error.READONLY
was not done properly. Now it is fixed.

Closes #96