### PR TITLE
Release all taken tasks on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ If there are no 'ready' tasks in the queue, returns nil.
 * `tube:bury(task_id)` - buries a task
 * `tube:kick(count)` - digs out `count` tasks
 * `tube:peek(task_id)` - return the task state by ID
+* `tube:tasks_by_state(task_state)` - return the iterator to tasks in a certain state
 * `tube:truncate()` - delete all tasks from the tube. Note that `tube:truncate`
 must be called only by the user who created this tube (has space ownership) OR
 under a `setuid` function. Read more about `setuid` functions

--- a/queue/abstract/driver/fifo.lua
+++ b/queue/abstract/driver/fifo.lua
@@ -121,6 +121,11 @@ function method.peek(self, id)
     return self.space:get{id}
 end
 
+-- get iterator to tasks in a certain state
+function method.tasks_by_state(self, task_state)
+    return self.space.index.status:pairs(task_state)
+end
+
 function method.truncate(self)
     self.space:truncate()
 end

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -348,6 +348,11 @@ function method.peek(self, id)
     return self.space:get{id}
 end
 
+-- get iterator to tasks in a certain state
+function method.tasks_by_state(self, task_state)
+    return self.space.index.status:pairs(task_state)
+end
+
 function method.truncate(self)
     self.space:truncate()
 end

--- a/queue/abstract/driver/utube.lua
+++ b/queue/abstract/driver/utube.lua
@@ -151,6 +151,11 @@ function method.peek(self, id)
     return self.space:get{id}
 end
 
+-- get iterator to tasks in a certain state
+function method.tasks_by_state(self, task_state)
+    return self.space.index.status:pairs(task_state)
+end
+
 function method.truncate(self)
     self.space:truncate()
 end

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -370,6 +370,11 @@ function method.peek(self, id)
     return self.space:get{id}
 end
 
+-- get iterator to tasks in a certain state
+function method.tasks_by_state(self, task_state)
+    return self.space.index.status:pairs(task_state)
+end
+
 function method.truncate(self)
     self.space:truncate()
 end

--- a/t/000-init.t
+++ b/t/000-init.t
@@ -43,5 +43,5 @@ test:test('access to queue after box.cfg{}', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/001-tube-init.t
+++ b/t/001-tube-init.t
@@ -23,5 +23,5 @@ test:test('test queue mock addition', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/010-fifo.t
+++ b/t/010-fifo.t
@@ -3,7 +3,7 @@ local yaml  = require('yaml')
 local fiber = require('fiber')
 
 local test = require('tap').test()
-test:plan(14)
+test:plan(15)
 
 local queue = require('queue')
 local state = require('queue.abstract.state')
@@ -290,6 +290,36 @@ test:test('if_not_exists test', function(test)
         if_not_exists = true, engine = engine
     })
     test:isnt(tube, tube_new, "if_not_exists if tube doesn't exists")
+end)
+
+test:test('Get tasks by state test', function(test)
+    test:plan(2)
+    local tube = queue.create_tube('test_task_it', 'fifo')
+
+    for i = 1, 10 do
+        tube:put('test_data' .. tostring(i))
+    end
+    for i = 1, 4 do
+        tube:take(0.001)
+    end
+
+    local count_taken = 0
+    local count_ready = 0
+
+    for _, task in tube.raw:tasks_by_state(state.READY) do
+        if task[2] == state.READY then
+            count_ready = count_ready + 1
+        end
+    end
+
+    for _, task in tube.raw:tasks_by_state(state.TAKEN) do
+        if task[2] == state.TAKEN then
+            count_taken = count_taken + 1
+        end
+    end
+
+    test:is(count_ready, 6, 'Check tasks count in a ready state')
+    test:is(count_taken, 4, 'Check tasks count in a taken state')
 end)
 
 tnt.finish()

--- a/t/010-fifo.t
+++ b/t/010-fifo.t
@@ -323,5 +323,5 @@ test:test('Get tasks by state test', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/020-fifottl.t
+++ b/t/020-fifottl.t
@@ -293,5 +293,5 @@ test:test('Get tasks by state test', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/020-fifottl.t
+++ b/t/020-fifottl.t
@@ -2,7 +2,7 @@
 local fiber = require('fiber')
 
 local test = require('tap').test()
-test:plan(15)
+test:plan(16)
 
 local queue = require('queue')
 local state = require('queue.abstract.state')
@@ -262,6 +262,35 @@ test:test('buried task in a dropped queue', function(test)
     test:ok(true, 'queue does not hang')
 end)
 
+test:test('Get tasks by state test', function(test)
+    test:plan(2)
+    local tube = queue.create_tube('test_task_it', 'fifottl')
+
+    for i = 1, 10 do
+        tube:put('test_data' .. tostring(i))
+    end
+    for i = 1, 4 do
+        tube:take(0.001)
+    end
+
+    local count_taken = 0
+    local count_ready = 0
+
+    for _, task in tube.raw:tasks_by_state(state.READY) do
+        if task[2] == state.READY then
+            count_ready = count_ready + 1
+        end
+    end
+
+    for _, task in tube.raw:tasks_by_state(state.TAKEN) do
+        if task[2] == state.TAKEN then
+            count_taken = count_taken + 1
+        end
+    end
+
+    test:is(count_ready, 6, 'Check tasks count in a ready state')
+    test:is(count_taken, 4, 'Check tasks count in a taken state')
+end)
 
 tnt.finish()
 os.exit(test:check() == true and 0 or -1)

--- a/t/030-utube.t
+++ b/t/030-utube.t
@@ -3,7 +3,7 @@ local yaml  = require('yaml')
 local fiber = require('fiber')
 
 local test = (require('tap')).test()
-test:plan(11)
+test:plan(12)
 
 local queue = require('queue')
 local state = require('queue.abstract.state')
@@ -154,6 +154,36 @@ test:test('if_not_exists test', function(test)
         if_not_exists = true, engine = engine
     })
     test:isnt(tube, tube_new, "if_not_exists if tube doesn't exists")
+end)
+
+test:test('Get tasks by state test', function(test)
+    test:plan(2)
+    local tube = queue.create_tube('test_task_it', 'utube')
+
+    for i = 1, 10 do
+        tube:put('test_data' .. tostring(i), { utube = i })
+    end
+    for i = 1, 4 do
+        tube:take(0.001)
+    end
+
+    local count_taken = 0
+    local count_ready = 0
+
+    for _, task in tube.raw:tasks_by_state(state.READY) do
+        if task[2] == state.READY then
+            count_ready = count_ready + 1
+        end
+    end
+
+    for _, task in tube.raw:tasks_by_state(state.TAKEN) do
+        if task[2] == state.TAKEN then
+            count_taken = count_taken + 1
+        end
+    end
+
+    test:is(count_ready, 6, 'Check tasks count in a ready state')
+    test:is(count_taken, 4, 'Check tasks count in a taken state')
 end)
 
 tnt.finish()

--- a/t/030-utube.t
+++ b/t/030-utube.t
@@ -187,5 +187,5 @@ test:test('Get tasks by state test', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/040-utubettl.t
+++ b/t/040-utubettl.t
@@ -288,5 +288,5 @@ test:test('Get tasks by state test', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/050-ttl.t
+++ b/t/050-ttl.t
@@ -58,5 +58,5 @@ test:test('many messages, one queue utttl', function (test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/060-async.t
+++ b/t/060-async.t
@@ -54,5 +54,5 @@ end)
 
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua:

--- a/t/070-compat.t
+++ b/t/070-compat.t
@@ -42,5 +42,5 @@ test:test("check compatibility names", function(test)
     test:is(str_name("1.7.1-168"),   "str",      "check old name (str)")
 end)
 
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua:

--- a/t/080-otc-cb.t
+++ b/t/080-otc-cb.t
@@ -45,5 +45,5 @@ test:test('on_task_change callback', function(test)
 end)
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/090-grant-check.t
+++ b/t/090-grant-check.t
@@ -166,5 +166,5 @@ end)
 
 tnt.finish()
 
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :

--- a/t/100-limfifottl.t
+++ b/t/100-limfifottl.t
@@ -68,5 +68,5 @@ else
 end
 
 tnt.finish()
-os.exit(test:check() == true and 0 or -1)
+os.exit(test:check() and 0 or 1)
 -- vim: set ft=lua :


### PR DESCRIPTION
If some tasks have been taken and don't released before shutdown
of the tarantool instance (for example: tarantool instance has been killed)
such task go to 'hung' state (noone can take the task now).
So, we must release all taken tasks on start of the queue module.

Fixes #66