### PR TITLE
Validate indexes of queue space in driver.new() method

### DIFF
--- a/queue/abstract/driver/fifo.lua
+++ b/queue/abstract/driver/fifo.lua
@@ -33,8 +33,21 @@ function tube.create_space(space_name, opts)
     return space
 end
 
+-- validate space of queue
+local function validate_space(space)
+    -- check indexes
+    if space.index.task_id == nil then
+        error('space does not have task_id index')
+    end
+    if space.index.status == nil then
+        error("space does not have status index")
+    end
+end
+
 -- start tube on space
 function tube.new(space, on_task_change)
+    validate_space(space)
+
     on_task_change = on_task_change or (function() end)
     local self = setmetatable({
         space          = space,

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -177,8 +177,24 @@ local function fifottl_fiber(self)
     end
 end
 
+-- validate space of queue
+local function validate_space(space)
+    -- check indexes
+    if space.index.task_id == nil then
+        error("space does not have task_id index")
+    end
+    if space.index.status == nil then
+        error("space does not have status index")
+    end
+    if space.index.watch == nil then
+        error("space does not have watch index")
+    end
+end
+
 -- start tube on space
 function tube.new(space, on_task_change, opts)
+    validate_space(space)
+    
     on_task_change = on_task_change or (function() end)
     local self = setmetatable({
         space           = space,

--- a/queue/abstract/driver/utube.lua
+++ b/queue/abstract/driver/utube.lua
@@ -41,8 +41,24 @@ function tube.create_space(space_name, opts)
     return space
 end
 
+-- validate space of queue
+local function validate_space(space)
+    -- check indexes
+    if space.index.task_id == nil then
+        error("space does not have task_id index")
+    end
+    if space.index.status == nil then
+        error("space does not have status index")
+    end
+    if space.index.utube == nil then
+        error("space does not have utube index")
+    end
+end
+
 -- start tube on space
 function tube.new(space, on_task_change)
+    validate_space(space)
+    
     on_task_change = on_task_change or (function() end)
     local self = setmetatable({
         space          = space,

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -186,8 +186,27 @@ local function utubettl_fiber(self)
     end
 end
 
+-- validate space of queue
+local function validate_space(space)
+    -- check indexes
+    if space.index.task_id == nil then
+        error("space does not have task_id index")
+    end
+    if space.index.status == nil then
+        error("space does not have status index")
+    end
+    if space.index.watch == nil then
+        error("space does not have watch index")
+    end
+    if space.index.utube == nil then
+        error("space does not have utube index")
+    end
+end
+
 -- start tube on space
 function tube.new(space, on_task_change, opts)
+    validate_space(space)
+
     on_task_change = on_task_change or (function() end)
     local self = setmetatable({
         space           = space,


### PR DESCRIPTION
Currently for all queue implementations  `driver.new()` does not validate queue space, created by `driver.create_space()` method. However corrupted space can lead to unexpected behavior (for example, see #134),

This one adds check to ensure, that indexes, created by `driver.create_space()`, really exist.