### PR TITLE
travis-ci: remove Ubuntu Cosmic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,6 @@ jobs:
     - <<: *packpack
       env: OS=ubuntu DIST=bionic
     - <<: *packpack
-      env: OS=ubuntu DIST=cosmic
-    - <<: *packpack
       env: OS=ubuntu DIST=disco
     - <<: *packpack
       env: OS=debian DIST=jessie


### PR DESCRIPTION
It reached EOL and the CI job fails with the following output:

```
sudo apt-get update > /dev/null
E: The repository 'http://security.ubuntu.com/ubuntu cosmic-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-backports Release' does not have a Release file.
```