### PR TITLE
travis-ci: update distributives and repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ _packpack: &packpack
       repository: "2x"
     - <<: *deploy_to_packagecloud
       repository: "2_2"
+    - <<: *deploy_to_packagecloud
+      repository: "2_3"
+    - <<: *deploy_to_packagecloud
+      repository: "2_4"
 
 jobs:
   include:
@@ -55,6 +59,10 @@ jobs:
     - env: VERSION=2x
       script: ./test.sh
     - env: VERSION=2_2
+      script: ./test.sh
+    - env: VERSION=2_3
+      script: ./test.sh
+    - env: VERSION=2_4
       script: ./test.sh
 
     - stage: deploy
@@ -78,11 +86,15 @@ jobs:
     - <<: *packpack
       env: OS=el DIST=7
     - <<: *packpack
+      env: OS=el DIST=8
+    - <<: *packpack
       env: OS=fedora DIST=28
     - <<: *packpack
       env: OS=fedora DIST=29
     - <<: *packpack
       env: OS=fedora DIST=30
+    - <<: *packpack
+      env: OS=fedora DIST=31
     - <<: *packpack
       env: OS=ubuntu DIST=trusty
     - <<: *packpack
@@ -91,6 +103,8 @@ jobs:
       env: OS=ubuntu DIST=bionic
     - <<: *packpack
       env: OS=ubuntu DIST=disco
+    - <<: *packpack
+      env: OS=ubuntu DIST=eoan
     - <<: *packpack
       env: OS=debian DIST=jessie
     - <<: *packpack


### PR DESCRIPTION
* Deploy packages for CentOS 8, Fedora 31 and Ubuntu Eoan.
* Test on tarantool 2.3 and 2.4.
* Deploy packages to 2.3 and 2.4 repositories.