### PR TITLE
Remove unneeded transform in tube.delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,8 @@ which is passed on to the user (removes the administrative fields)
 Returns a normalized task which represents a tuple in the space
 * `tube:take()` - sets the task state to 'in progress' and returns the task.
 If there are no 'ready' tasks in the queue, returns nil.
-* `tube:delete(task_id)` - deletes a task from the queue
+* `tube:delete(task_id)` - deletes a task from the queue.
+Returns the original task with a state changed to 'done'
 * `tube:release(task_id, opts)` - puts a task back to the queue (in the 'ready'
    state)
 * `tube:bury(task_id)` - buries a task

--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -222,8 +222,7 @@ end
 
 function tube.delete(self, id)
     self:peek(id)
-    return self.raw:normalize_task(
-        self.raw:delete(id):transform(2, 1, state.DONE))
+    return self.raw:normalize_task(self.raw:delete(id))
 end
 
 -- drop tube


### PR DESCRIPTION
Continue of https://github.com/tarantool/queue/pull/70

All the queue drivers do "transform(2, 1, state.DONE)" before returning the task from their "delete" method. Also, changing the status of a task from abstract.lua is a violation of encapsulation.
    
Patch changes:
* remove the unnecessary "transform" operation from "tube.delete"
* update description of a driver delete method in documentation

ChangeLog: Updated the requirements for  the "delete" driver method. Now, the method should change the state of a task to "done". Before, it was duplicated by external code.