### PR TITLE
Fix release all tasks

### DIFF
--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -72,12 +72,13 @@ local function tube_release_all_tasks(tube)
         log.error(prefix .. 'no stable iterator support: skip task releasing')
         log.error(prefix .. 'some tasks may stuck in taken state perpetually')
         log.error(prefix .. 'update tarantool to >= 1.7.5 or take the risk')
+        return
     end
 
     log.info(prefix .. 'releasing all taken task (may take a while)')
     local released = 0
     for _, task in tube.raw:tasks_by_state(state.TAKEN) do
-        tube.raw:release(task[1])
+        tube.raw:release(task[1], {})
         released = released + 1
     end
     log.info(prefix .. ('released %d tasks'):format(released))

--- a/t/130-release-all-tasks-on-start.t
+++ b/t/130-release-all-tasks-on-start.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env tarantool
+
+local os = require('os')
+local queue = require('queue')
+local tap = require('tap')
+local tnt = require('t.tnt')
+
+local test = tap.test('release all tasks on start')
+test:plan(1)
+
+---
+-- Accept gh-66, we need to release all taken tasks on start.
+-- Instead of tarantool reboot, we will additionally call queue.start()
+-- to simulate the reload of the module. This is not a clean enough,
+-- because fibers launched by the module are not cleaned up.
+-- See https://github.com/tarantool/queue/issues/66
+--
+-- All tricks in this test are done by professionals, don't try
+-- to repeat it yourself!!!
+local function check_release_tasks_on_start()
+    tnt.cfg()
+    -- The "fifottl" driver was choosen for check gh-121.
+    -- We cann't use opts == nil as argument for driver "release"
+    -- method. This is the policy of the module "queue" (check
+    -- opts in abstract.lua, instead to check inside the driver).
+    -- See https://github.com/tarantool/queue/issues/121
+    local driver = 'fifottl'
+    local tube = queue.create_tube('test_tube', driver)
+
+    tube:put('1')
+    tube:put('2')
+    tube:put('3')
+
+    tube:take()
+    tube:take()
+    tube:take()
+
+    -- Simulate the module reload.
+    queue.start()
+
+    local ready_tasks_num = queue.statistics()['test_tube']['tasks']['ready']
+    test:is(ready_tasks_num, 3, 'check release tasks on start')
+end
+
+check_release_tasks_on_start()
+
+tnt.finish()
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
* Added return in case of tarantool version < 1.7.5
* Instead of nil, an empty table is used as "opts" argument of the driver "release" method. This is the policy of the module "queue": "Check opts in abstract.lua, instead to check inside the driver".
* Added a test for release all tasks on start.

Follow-up #66
Fixes #121

ChangeLog: fix the tasks releases on start for some drivers(utubettl, fifottl, limfifottl).