### PR TITLE
Update "register_driver"

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,13 +614,13 @@ Registering a custom driver
 Driver class must implement the following API:
 
 1. `new` (constructs an instance of a driver), takes:
-  * the space object, in which the driver must store its tasks
-  * a callback to notify the main queue framework on a task state change
+    * the space object, in which the driver must store its tasks
+    * a callback to notify the main queue framework on a task state change
   (`on_task_change`)
-  * options of the queue (a Lua table)
+    * options of the queue (a Lua table)
 1. `create_space` - creates the supporting space. The arguments are:
-  * space name
-  * space options
+    * space name
+    * space options
 
 To sum up, when the user creates a new queue, the queue framework
 passes the request to the driver, asking it to create a space to

--- a/README.md
+++ b/README.md
@@ -601,6 +601,14 @@ notify the framework about the change.
 I.e. for normal operation, even errors during normal operation, there
 should be no exceptions.
 
+Registering a custom driver
+
+`register_driver(driver_name, tube_ctr)` - queue method is used to register
+  a custom driver. The arguments are:
+  * driver_name: unique driver name. Must be different from the core drivers
+  names.
+  * tube_ctr: implementation of tube control methods("create_space" and "new").
+
 ## Driver API
 
 Driver class must implement the following API:

--- a/README.md
+++ b/README.md
@@ -646,6 +646,8 @@ Returns the original task with a state changed to 'done'
 * `tube:bury(task_id)` - buries a task
 * `tube:kick(count)` - digs out `count` tasks
 * `tube:peek(task_id)` - return the task state by ID
+* `tube:touch(task_id, delta)` - increases `ttr` and `ttl` of the task by delta
+seconds. If queue does not support `ttr`, error will be thrown. Returns the task
 * `tube:tasks_by_state(task_state)` - return the iterator to tasks in a certain state
 * `tube:truncate()` - delete all tasks from the tube. Note that `tube:truncate`
 must be called only by the user who created this tube (has space ownership) OR

--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -54,15 +54,6 @@ local function event_time(tm)
     return tm
 end
 
--- load all drivers
-queue.driver = {
-    fifo        = require('queue.abstract.driver.fifo'),
-    fifottl     = require('queue.abstract.driver.fifottl'),
-    utube       = require('queue.abstract.driver.utube'),
-    utubettl    = require('queue.abstract.driver.utubettl'),
-    limfifottl  = require('queue.abstract.driver.limfifottl')
-}
-
 local function tube_release_all_tasks(tube)
     local prefix = ('queue: [tube "%s"] '):format(tube.name)
 

--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -669,12 +669,4 @@ setmetatable(queue.stat, {
     }
 )
 
-queue.register_driver = function(driver_name, tube_ctr)
-    if type(tube_ctr.create_space) ~= 'function' or
-       type(tube_ctr.new) ~= 'function' then
-        error('tube control methods must contain functions "create_space" and "new"')
-    end
-    queue.driver[driver_name] = tube_ctr
-end
-
 return setmetatable(queue, { __index = method })

--- a/queue/init.lua
+++ b/queue/init.lua
@@ -1,13 +1,17 @@
 local queue = nil
+
+local function register_driver(driver_name, tube_ctr)
+    if type(tube_ctr.create_space) ~= 'function' or
+        type(tube_ctr.new) ~= 'function' then
+        error('tube control methods must contain functions "create_space"'
+              .. ' and "new"')
+    end
+    queue.driver[driver_name] = tube_ctr
+end
+
 queue = setmetatable({
     driver = {},
-    register_driver = function(driver_name, tube_ctr)
-        if type(tube_ctr.create_space) ~= 'function' or
-           type(tube_ctr.new) ~= 'function' then
-            error('tube control methods must contain functions "create_space" and "new"')
-        end
-        queue.driver[driver_name] = tube_ctr
-    end,
+    register_driver = register_driver,
 }, { __index = function() print(debug.traceback()) error("Please run box.cfg{} first") end })
 
 if rawget(box, 'space') == nil then
@@ -34,6 +38,7 @@ if rawget(box, 'space') == nil then
     end
 else
     queue = require 'queue.abstract'
+    queue.register_driver = register_driver
     queue.start()
 end
 

--- a/queue/init.lua
+++ b/queue/init.lua
@@ -15,6 +15,9 @@ local function register_driver(driver_name, tube_ctr)
         error('tube control methods must contain functions "create_space"'
               .. ' and "new"')
     end
+    if queue.driver[driver_name] then
+        error(('overriding registered driver "%s"'):format(driver_name))
+    end
     queue.driver[driver_name] = tube_ctr
 end
 

--- a/t/001-tube-init.t
+++ b/t/001-tube-init.t
@@ -12,11 +12,17 @@ local engine = os.getenv('ENGINE') or 'memtx'
 local mock_tube = { create_space = function() end, new = function() end }
 
 test:test('test queue mock addition', function(test)
-    test:plan(2)
+    test:plan(3)
 
     local queue = require('queue')
     queue.register_driver('mock', mock_tube)
     test:is(queue.driver.mock, mock_tube)
+
+    local res, err = pcall(queue.register_driver, 'mock', mock_tube)
+    local check = not res and
+        string.match(err, 'overriding registered driver') ~= nil
+    test:ok(check, 'check a driver override failure')
+
     tnt.cfg{}
 
     test:is(queue.driver.mock, mock_tube)

--- a/t/140-register-driver-after-cfg.t
+++ b/t/140-register-driver-after-cfg.t
@@ -3,7 +3,7 @@ local tap = require('tap')
 local tnt = require('t.tnt')
 
 local test = tap.test('test driver register')
-test:plan(2)
+test:plan(3)
 
 local mock_tube = {
     create_space = function() end,
@@ -35,6 +35,11 @@ local function check_driver_register()
     end
 
     test:ok(check_standart_drivers, 'standard drivers are defined')
+
+    local res, err = pcall(queue.register_driver, 'mock', mock_tube)
+    local check = not res and
+        string.match(err, 'overriding registered driver') ~= nil
+    test:ok(check, 'check a driver override failure')
 end
 
 check_driver_register()

--- a/t/140-register-driver-after-cfg.t
+++ b/t/140-register-driver-after-cfg.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env tarantool
+local tap = require('tap')
+local tnt = require('t.tnt')
+
+local test = tap.test('test driver register')
+test:plan(2)
+
+local mock_tube = {
+    create_space = function() end,
+    new = function() end
+}
+
+-- As opposed to 001-tube-init.t, queue initialization
+-- and driver registration are done after cfg().
+local function check_driver_register()
+    tnt.cfg()
+    local queue = require('queue')
+    queue.register_driver('mock', mock_tube)
+    test:is(queue.driver.mock, mock_tube, 'driver has been registered')
+
+    local standart_drivers = {
+        'fifo',
+        'fifottl',
+        'limfifottl',
+        'utube',
+        'utubettl'
+    }
+    local check_standart_drivers = true
+
+    for _, v in pairs(standart_drivers) do
+        if queue.driver[v] == nil then
+            check_standart_drivers = false
+            break
+        end
+    end
+
+    test:ok(check_standart_drivers, 'standard drivers are defined')
+end
+
+check_driver_register()
+
+tnt.finish()
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Changes of patchset:
* Double definition of the "register_driver" method has been removed
* Loading core drivers of the queue has been moved from abstract.lua to init.lua
* Added check for driver overriding
* Added description of the "register_driver" method
* Driver API description has been fixed
* Added description of the "touch" driver API method

ChangeLog:
* Check for driver overriding added. Previously, such check existed only for the core drivers in the case of a delayed start (when the queue module tried to initialize before the box configuration.).
* Description of the "register_driver" method was added.
* Description of the "touch" driver API method was added.