### PR TITLE
travis-ci: remove Ubuntu Disco, add Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,9 @@ jobs:
     - <<: *packpack
       env: OS=ubuntu DIST=bionic
     - <<: *packpack
-      env: OS=ubuntu DIST=disco
-    - <<: *packpack
       env: OS=ubuntu DIST=eoan
+    - <<: *packpack
+      env: OS=ubuntu DIST=focal
     - <<: *packpack
       env: OS=debian DIST=jessie
     - <<: *packpack


### PR DESCRIPTION
Ubuntu Disco is EOL and fails in CI on apt repositories updating with 'does not have a Release file' errors.