### PR TITLE
fix custom driver registration after reboot

### DIFF
--- a/queue/init.lua
+++ b/queue/init.lua
@@ -77,6 +77,8 @@ function wrapper_impl(...)
             rawset(queue, name, val)
         end
         abstract.driver = queue.driver
+        -- Now the "register_driver" method from abstract will be used.
+        queue.register_driver = nil
         setmetatable(queue, getmetatable(abstract))
         queue.start()
     else
@@ -95,7 +97,6 @@ local function queue_init()
     if rawget(box, 'space') ~= nil and box.info.ro == false then
         -- The box was configured with read_only = false
         queue = require('queue.abstract')
-        queue.register_driver = register_driver
         queue.driver = core_drivers
         queue.start()
     else

--- a/t/170-register-driver-after-reload.t
+++ b/t/170-register-driver-after-reload.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env tarantool
+
+local os = require('os')
+local queue = require('queue')
+local tap = require('tap')
+local tnt = require('t.tnt')
+
+local test = tap.test('custom driver registration after reload')
+test:plan(1)
+
+tnt.cfg()
+
+--- Accept gh-137, we need to check custom driver registration
+-- after restart. Instead of tarantool reboot, we will additionally
+-- call queue.start() to simulate the reload of the module. This
+-- is not a clean enough, because queue module doesn't provide the
+-- hot restart.
+--
+-- All tricks in this test are done by professionals, don't try
+-- to repeat it yourself!!!
+local function check_driver_registration_after_reload()
+    local fifo = require('queue.abstract.driver.fifo')
+    queue.register_driver('fifo_cust', fifo)
+
+    local tube = queue.create_tube('tube_cust', 'fifo_cust')
+    tube:put('1')
+    local task_id = tube:take()[1]
+
+    -- Simulate the module reload.
+    queue.driver.fifo_cust = nil
+    queue.start()
+
+    -- Check the task has been released after reload.
+    queue.register_driver('fifo_cust', fifo)
+    local task_status = queue.tube.tube_cust:peek(task_id)[2]
+    test:is(task_status, 'r', 'check driver registration after reload')
+end
+
+check_driver_registration_after_reload()
+
+tnt.finish()
+os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
Previously, if a custom driver is registered after calling box.cfg() it causes a problem when the instance will be restarted. The cause of the problem is an attempt to recreate a tube of custom type (which is not registered yet).
This bug is now fixed.

Fixes #137

@ChangeLog:  fix custom driver registration after reboot. Previously, if a custom driver is registered after calling box.cfg() it causes a problem when the instance will be restarted. The cause of the problem is an attempt to recreate a tube of custom type (which is not registered yet).