### PR TITLE
fix the shadowing of the variable "space"

### DIFF
--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -436,16 +436,16 @@ end
 
 -- function takes tuples and recreates tube
 local function recreate_tube(tube_tuple)
-    local name, id, space, tube_type, opts = tube_tuple:unpack()
+    local name, id, space_name, tube_type, opts = tube_tuple:unpack()
 
     local driver = queue.driver[tube_type]
     if driver == nil then
         error("Unknown tube type " .. tostring(tube_type))
     end
 
-    local space = box.space[space]
+    local space = box.space[space_name]
     if space == nil then
-        error(("Space '%s' doesn't exists"):format(space))
+        error(("Space '%s' doesn't exists"):format(space_name))
     end
     return make_self(driver, space, name, tube_type, id, opts)
 end


### PR DESCRIPTION
The local variable "space" is defined twice in `recreate_tube()`.
First time it's a name of the space, the second - it's a space object.
If there is no space, we will try to thrown an error with the name of
the space, but `nil` will be used instead.