### PR TITLE
travis-ci: remove Ubuntu Eoan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,6 @@ jobs:
     - <<: *packpack
       env: OS=ubuntu DIST=bionic
     - <<: *packpack
-      env: OS=ubuntu DIST=eoan
-    - <<: *packpack
       env: OS=ubuntu DIST=focal
     - <<: *packpack
       env: OS=debian DIST=jessie


### PR DESCRIPTION
Ubuntu Eoan is EOL and fails in CI on apt repositories updating with
'does not have a Release file' errors.