### PR TITLE
Option to keep the ttl while releasing the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,12 @@ Example: queue.tube.list_of_sites:release(15, {delay=10})
 Note: in the above example, the delay option means
 "the task cannot be executed again for 10 seconds".
 
+Example: queue.tube.list_of_sites:release(15, {delay=10, touch_ttl=false})
+
+Note: in the above example, the delay option means
+"the task cannot be executed again for 10 seconds" and
+the associated touch_ttl option means "the task ttl stays unchanged"
+
 ## Peeking at a task
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -551,11 +551,11 @@ Example: queue.tube.list_of_sites:release(15, {delay=10})
 Note: in the above example, the delay option means
 "the task cannot be executed again for 10 seconds".
 
-Example: queue.tube.list_of_sites:release(15, {delay=10, touch_ttl=false})
+Example: queue.tube.list_of_sites:release(15, {delay=10, keep_ttl=true})
 
 Note: in the above example, the delay option means
 "the task cannot be executed again for 10 seconds" and
-the associated touch_ttl option means "the task ttl stays unchanged"
+the associated keep_ttl option means "the task ttl stays unchanged"
 
 ## Peeking at a task
 

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -300,12 +300,18 @@ function method.release(self, id, opts)
     if task == nil then
         return
     end
+    if opts.touch_ttl == nil then opts.touch_ttl = true end
     if opts.delay ~= nil and opts.delay > 0 then
-        task = self.space:update(id, {
+        local upd = {
             { '=', i_status, state.DELAYED },
-            { '=', i_next_event, util.event_time(opts.delay) },
+            { '=', i_next_event, util.event_time(opts.delay) }
+        }
+        if opts.touch_ttl then
+            table.insert(upd,
             { '+', i_ttl, util.time(opts.delay) }
-        })
+            )
+        end
+        task = self.space:update(id, upd)
     else
         task = self.space:update(id, {
             { '=', i_status, state.READY },

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -300,13 +300,12 @@ function method.release(self, id, opts)
     if task == nil then
         return
     end
-    if opts.touch_ttl == nil then opts.touch_ttl = true end
     if opts.delay ~= nil and opts.delay > 0 then
         local upd = {
             { '=', i_status, state.DELAYED },
             { '=', i_next_event, util.event_time(opts.delay) }
         }
-        if opts.touch_ttl then
+        if not opts.keep_ttl then
             table.insert(upd,
             { '+', i_ttl, util.time(opts.delay) }
             )

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -323,11 +323,16 @@ function method.release(self, id, opts)
         return
     end
     if opts.delay ~= nil and opts.delay > 0 then
-        task = self.space:update(id, {
+        local upd = {
             { '=', i_status, state.DELAYED },
-            { '=', i_next_event, util.event_time(opts.delay) },
+            { '=', i_next_event, util.event_time(opts.delay) }
+        }
+        if not opts.keep_ttl then
+            table.insert(upd,
             { '+', i_ttl, util.time(opts.delay) }
-        })
+            )
+        end
+        task = self.space:update(id, upd)
         if task ~= nil then
             return process_neighbour(self, task, 'release')
         end

--- a/t/020-fifottl.t
+++ b/t/020-fifottl.t
@@ -2,7 +2,7 @@
 local fiber = require('fiber')
 
 local test = require('tap').test()
-test:plan(16)
+test:plan(17)
 
 local queue = require('queue')
 local state = require('queue.abstract.state')
@@ -242,6 +242,21 @@ test:test('ttl after delay test', function(test)
     tube:release(0, { delay = DELTA })
     local task = box.space.test_ttl_release:get(0)
     test:is(task.ttl, (TTL + DELTA) * 1000000, 'check TTL after release')
+    test:is(task.ttr, TTR * 1000000, 'check TTR after release')
+end)
+
+test:test('ttl after delay test with keep_ttl', function(test)
+    local TTL = 10
+    local TTR = 20
+    local DELTA = 5
+    test:plan(2)
+    box.cfg{}
+    local tube = queue.create_tube('test_ttl_release_keep', 'fifottl', { if_not_exists = true })
+    tube:put({'test_task'}, { ttl = TTL, ttr = TTR })
+    tube:take()
+    tube:release(0, { delay = DELTA, keep_ttl = true })
+    local task = box.space.test_ttl_release_keep:get(0)
+    test:is(task.ttl, TTL * 1000000, 'check TTL after release')
     test:is(task.ttr, TTR * 1000000, 'check TTR after release')
 end)
 

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ VERSION=${VERSION:-2_2}
 
 curl -sfL https://packagecloud.io/tarantool/${VERSION}/gpgkey | sudo apt-key add -
 release=`lsb_release -c -s`
+release='focal'
 
 sudo apt-get install -y apt-transport-https
 


### PR DESCRIPTION
Adds the option 'touch_ttl' that is assotiated with delay option in the release method of fifottl. Allows keep the task ttl unchanged when it necessary. Might help with retries.