### PR TITLE
tests: add missing vim modeline

### DIFF
--- a/t/110-disconnect-trigger-check.t
+++ b/t/110-disconnect-trigger-check.t
@@ -96,3 +96,4 @@ local function test_lost_session_id_after_yield()
 end
 
 test_lost_session_id_after_yield()
+-- vim: set ft=lua :

--- a/t/120-take-task-after-reconnect.t
+++ b/t/120-take-task-after-reconnect.t
@@ -60,3 +60,4 @@ test:test('Don\'t take a task after disconnect', test_take_task_after_disconnect
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/130-release-all-tasks-on-start.t
+++ b/t/130-release-all-tasks-on-start.t
@@ -46,3 +46,4 @@ check_release_tasks_on_start()
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/140-register-driver-after-cfg.t
+++ b/t/140-register-driver-after-cfg.t
@@ -46,3 +46,4 @@ check_driver_register()
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/150-lazy-start.t
+++ b/t/150-lazy-start.t
@@ -31,3 +31,4 @@ check_lazy_start()
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/160-validate-space.t
+++ b/t/160-validate-space.t
@@ -105,3 +105,4 @@ end)
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/170-register-driver-after-reload.t
+++ b/t/170-register-driver-after-reload.t
@@ -40,3 +40,4 @@ check_driver_registration_after_reload()
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/180-work-with-uuid.t
+++ b/t/180-work-with-uuid.t
@@ -186,3 +186,4 @@ end)
 
 tnt.finish()
 os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :


### PR DESCRIPTION
Tests from 000 to 100 has vim modeline with filetype specified.
This patch adds filetype into remaining tests.