### PR TITLE
Add master-replica switching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ align="right">
   * [Fields of the \_queue\_session\_ids space](#fields-of-the-_queue_session_ids-space)
   * [Fields of the space associated with each queue](#fields-of-the-space-associated-with-each-queue)
 * [Task state diagram](#task-state-diagram)
+* [Queue state diagram](#queue-state-diagram)
 * [Installing](#installing)
 * [Using the queue module](#using-the-queue-module)
   * [Initialization](#initialization)
@@ -37,7 +38,9 @@ align="right">
   * [Kicking a number of tasks](#kicking-a-number-of-tasks)
   * [Deleting a task](#deleting-a-task)
   * [Dropping a queue](#dropping-a-queue)
+  * [Releasing all taken tasks](#releasing-all-taken-tasks)
   * [Getting statistics](#getting-statistics)
+  * [Queue and replication](#queue-and-replication)
 * [Implementation details](#implementation-details)
   * [Queue drivers](#queue-drivers)
   * [Driver API](#driver-api)
@@ -256,7 +259,7 @@ space; the client waits for tasks in this queue
 1. `timeout` - the client wait timeout
 1. `time` - the time when the client took a task
 
-The `_queue_taken_2` (`_queue_taken` is deprecated) temporary space contains
+The `_queue_taken_2` (`_queue_taken` is deprecated) space contains
 tuples for each job which is processing a task in the queue.
 
 ## Fields of the `_queue_taken_2` space
@@ -275,6 +278,11 @@ session id) to the session UUID.
 
 1. `connection_id` - connection id (numeric)
 2. `session_uuid` - session UUID (string)
+
+## Fields of the `_queue_inactive_sessions` space
+
+1. `uuid` - session UUID (string)
+2. `exp_time` - session expiration time (numeric)
 
 Also, there is a space which is associated with each queue,
 which is named in the `space` field of the `_queue` space.
@@ -322,6 +330,48 @@ For information on the transition triggers, refer to:
 the sections of the corresponding [queue types](#queue-types).
 
 ![Task state diagram](./doc/images/statediagram.svg)
+
+# Queue state diagram
+
+Queue can be used in a master-replica scheme:
+
+There are five states for queue:
+* INIT
+* STARTUP
+* RUNNING
+* ENDING
+* WAITING
+
+When the tarantool is launched for the first time,
+the state of the queue is always `INIT` until `box.info.ro` is false.
+
+States switching scheme:
+```mermaid
+flowchart LR
+      I(("init"))-->S[startup]
+      S[startup]-->R[running]
+      W[waiting]--> |"(ro ->rw)"| S[startup]
+      R[running]--> |"(ro ->rw)"| E[ending]
+      E[ending]-->W[waiting]
+```
+
+Current queue state can be shown by using `queue.state()` method.
+
+In the `STARTUP` state, the queue is waiting for possible data synchronization
+with other cluster members by the time of the largest upstream lag multiplied
+by two. After that, all taken tasks are released, except for tasks with
+session uuid matching inactive sessions uuids. This makes possible to take
+a task, switch roles on the cluster, and release the task within the timeout
+specified by the `queue.cfg({ttr = N})` parameter. Note: all clients that `take()`
+and do not `ack()/release()` tasks must be disconnected before changing the role.
+And the last step in the `STARTUP` state is starting tube driver using new
+method called `start()`.
+
+In the `RUNNING` state, the queue is working as usually. The `ENDING` state calls
+`stop()` method. in the `WAITING` state, the queue listens for a change in the
+read_only flag.
+
+All states except `INIT` is controlled by new fiber called `queue_state_fiber`.
 
 # Installing
 
@@ -625,6 +675,14 @@ Reverse the effect of a `create` request.
 Effect: remove the tuple from the `_queue` space,
 and drop the space associated with the queue.
 
+## Releasing all taken tasks
+
+```lua
+queue.tube.tube_name:release_all()
+```
+
+Forcibly returns all taken tasks to a ready state.
+
 ## Getting statistics
 
 ```lua
@@ -664,6 +722,84 @@ queue.statistics('list_of_sites')
      bury: 1
      put: 2
      delete: 1
+...
+```
+
+## Queue and replication
+
+Usage example:
+
+```lua
+-- Instance file for the master.
+box.cfg{
+  listen = 3301,
+  replication = {'replicator:password@127.0.0.1:3301',  -- Master URI.
+                 'replicator:password@127.0.0.1:3302'}, -- Replica URI.
+  read_only = false,
+}
+
+box.once("schema", function()
+   box.schema.user.create('replicator', {password = 'password'})
+   box.schema.user.grant('replicator', 'replication') -- grant replication role
+end)
+
+queue = require("queue")
+queue.cfg({ttr = 300}) -- Clean up session after 5 minutes after disconnect.
+require('console').start()
+os.exit()
+```
+
+```lua
+-- Instance file for the replica.
+box.cfg{
+  listen = 3302,
+  replication = {'replicator:password@127.0.0.1:3301',  -- Master URI.
+                 'replicator:password@127.0.0.1:3302'}, -- Replica URI.
+  read_only = true
+}
+
+queue = require("queue")
+queue.cfg({ttr = 300}) -- Clean up session after 5 minutes after disconnect.
+require('console').start()
+os.exit()
+```
+
+Start master and replica instances and check queue state:
+
+Master:
+```sh
+tarantool> queue.state()
+---
+- RUNNING
+...
+```
+
+Replica:
+```sh
+tarantool> queue.state()
+---
+- INIT
+...
+```
+
+Now reverse the `read_only` setting of the master and replica and check the
+status of the queue again.
+
+Master:
+```sh
+tarantool> box.cfg({read_only = true})
+tarantool> queue.state()
+---
+- WAITING
+...
+```
+
+Replica:
+```sh
+tarantool> box.cfg({read_only = false})
+tarantool> queue.state()
+---
+- RUNNING
 ...
 ```
 
@@ -710,6 +846,8 @@ Driver class must implement the following API:
 1. `create_space` - creates the supporting space. The arguments are:
     * space name
     * space options
+1. `start` - initialize internal resources if any, e.g. start fibers.
+1. `stop` - clean up internal resources if any, e.g. stop fibers.
 
 To sum up, when the user creates a new queue, the queue framework
 passes the request to the driver, asking it to create a space to

--- a/README.md
+++ b/README.md
@@ -280,10 +280,11 @@ is set to false.
 1. `connection_id` - connection id (numeric)
 2. `session_uuid` - session UUID (string)
 
-## Fields of the `_queue_inactive_sessions` space
+## Fields of the `_queue_shared_sessions` space
 
 1. `uuid` - session UUID (string)
 2. `exp_time` - session expiration time (numeric)
+3. `active` - session state (boolean)
 
 This space is temporary if `in_replicaset` is set to false.
 
@@ -363,12 +364,10 @@ Current queue state can be shown by using `queue.state()` method.
 In the `STARTUP` state, the queue is waiting for possible data synchronization
 with other cluster members by the time of the largest upstream lag multiplied
 by two. After that, all taken tasks are released, except for tasks with
-session uuid matching inactive sessions uuids. This makes possible to take
+session uuid matching shared sessions uuids. This makes possible to take
 a task, switch roles on the cluster, and release the task within the timeout
-specified by the `queue.cfg({ttr = N})` parameter. Note: all clients that `take()`
-and do not `ack()/release()` tasks must be disconnected before changing the role.
-And the last step in the `STARTUP` state is starting tube driver using new
-method called `start()`.
+specified by the `queue.cfg({ttr = N})` parameter. And the last step in the
+`STARTUP` state is starting tube driver using new method called `start()`.
 
 In the `RUNNING` state, the queue is working as usually. The `ENDING` state calls
 `stop()` method. in the `WAITING` state, the queue listens for a change in the

--- a/queue-scm-1.rockspec
+++ b/queue-scm-1.rockspec
@@ -19,6 +19,7 @@ build = {
         ['queue.abstract']                   = 'queue/abstract.lua',
         ['queue.abstract.state']             = 'queue/abstract/state.lua',
         ['queue.abstract.queue_session']     = 'queue/abstract/queue_session.lua',
+        ['queue.abstract.queue_state']       = 'queue/abstract/queue_state.lua',
         ['queue.abstract.driver.fifottl']    = 'queue/abstract/driver/fifottl.lua',
         ['queue.abstract.driver.utubettl']   = 'queue/abstract/driver/utubettl.lua',
         ['queue.abstract.driver.fifo']       = 'queue/abstract/driver/fifo.lua',

--- a/queue/CMakeLists.txt
+++ b/queue/CMakeLists.txt
@@ -10,6 +10,8 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/abstract/state.lua
         DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/abstract)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/abstract/queue_session.lua
         DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/abstract)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/abstract/queue_state.lua
+        DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/abstract)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/abstract/driver/fifo.lua
         DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/abstract/driver/)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/abstract/driver/utube.lua

--- a/queue/abstract/driver/fifo.lua
+++ b/queue/abstract/driver/fifo.lua
@@ -148,4 +148,14 @@ function method.truncate(self)
     self.space:truncate()
 end
 
+-- This driver has no background activity.
+-- Implement dummy methods for the API requirement.
+function method.start()
+    return
+end
+
+function method.stop()
+    return
+end
+
 return tube

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -170,7 +170,7 @@ local function fifottl_fiber(self)
         else
             -- When switching the master to the replica, the fiber will be stopped.
             if self.sync_chan:get(0.1) ~= nil then
-                print("Queue fifottl was stopped")
+                log.info("Queue fifottl fiber was stopped")
                 break
             end
         end

--- a/queue/abstract/driver/utube.lua
+++ b/queue/abstract/driver/utube.lua
@@ -175,4 +175,14 @@ function method.truncate(self)
     self.space:truncate()
 end
 
+-- This driver has no background activity.
+-- Implement dummy methods for the API requirement.
+function method.start()
+    return
+end
+
+function method.stop()
+    return
+end
+
 return tube

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -167,6 +167,7 @@ local function utubettl_fiber(self)
     while true do
         if box.info.ro == false then
             local stat, err = pcall(utubettl_fiber_iteration, self, processed)
+
             if not stat and not err.code == box.error.READONLY then
                 log.error("error catched: %s", tostring(err))
                 log.error("exiting fiber '%s'", fiber.name())
@@ -175,7 +176,11 @@ local function utubettl_fiber(self)
                 processed = err
             end
         else
-            fiber.sleep(0.1)
+            -- When switching the master to the replica, the fiber will be stopped.
+            if self.sync_chan:get(0.1) ~= nil then
+                print("Queue utubettl was stopped")
+                break
+            end
         end
     end
 end
@@ -199,6 +204,7 @@ function tube.new(space, on_task_change, opts)
 
     self.cond  = qc.waiter()
     self.fiber = fiber.create(utubettl_fiber, self)
+    self.sync_chan = fiber.channel()
 
     return self
 end
@@ -390,6 +396,22 @@ end
 
 function method.truncate(self)
     self.space:truncate()
+end
+
+function method.start(self)
+    if self.fiber then
+        return
+    end
+    self.fiber = fiber.create(utubettl_fiber, self)
+end
+
+function method.stop(self)
+    if not self.fiber then
+        return
+    end
+    self.cond:signal(self.fiber:id())
+    self.sync_chan:put(true)
+    self.fiber = nil
 end
 
 return tube

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -178,7 +178,7 @@ local function utubettl_fiber(self)
         else
             -- When switching the master to the replica, the fiber will be stopped.
             if self.sync_chan:get(0.1) ~= nil then
-                print("Queue utubettl was stopped")
+                log.info("Queue utubettl fiber was stopped")
                 break
             end
         end

--- a/queue/abstract/queue_state.lua
+++ b/queue/abstract/queue_state.lua
@@ -1,0 +1,127 @@
+-- Queue states.
+
+local log   = require('log')
+local fiber = require('fiber')
+
+--[[ States switching scheme:
+
+                       +-----------+
+                       |  RUNNING  |
+                       +-----------+
+                        ^         | (rw -> ro)
+      (ro -> rw)        |         v
++------+       +---------+       +--------+
+| INIT | --->  | STARTUP |       | ENDING |
++------+       +---------+       +--------+
+                        ^         |
+             (ro -> rw) |         v
+                       +-----------+
+                       |  WAITING  |
+                       +-----------+
+]]--
+
+local queue_state = {
+    states = {
+        INIT    = 'i',
+        STARTUP = 's',
+        RUNNING = 'r',
+        ENDING  = 'e',
+        WAITING = 'w',
+    }
+}
+
+local current = queue_state.states.INIT
+
+local function get_state_key(value)
+    for k, v in pairs(queue_state.states) do
+        if v == value then
+            return k
+        end
+    end
+
+    return nil
+end
+
+local function max_lag()
+    local max_lag = 0
+
+    for i = 1, #box.info.replication do
+        if box.info.replication[i].upstream then
+            local lag = box.info.replication[i].upstream.lag
+            if lag > max_lag then
+                max_lag = lag
+            end
+        end
+    end
+
+    return max_lag
+end
+
+local function create_state_fiber(on_state_change_cb)
+    log.info('Started queue state fiber')
+
+    fiber.create(function()
+        fiber.self():name('queue_state_fiber')
+        while true do
+            if current == queue_state.states.WAITING then
+                local rc = pcall(box.ctl.wait_rw, 0.001)
+                if rc then
+                    current = queue_state.states.STARTUP
+                    log.info('Queue state changed: STARTUP')
+                    -- Wait for maximum upstream lag * 2.
+                    fiber.sleep(max_lag() * 2)
+                    on_state_change_cb(current)
+                    current = queue_state.states.RUNNING
+                    log.info('Queue state changed: RUNNING')
+                end
+            elseif current == queue_state.states.RUNNING then
+                local rc = pcall(box.ctl.wait_ro, 0.001)
+                if rc then
+                    current = queue_state.states.ENDING
+                    on_state_change_cb(current)
+                    log.info('Queue state changed: ENDING')
+                    current = queue_state.states.WAITING
+                    log.info('Queue state changed: WAITING')
+                end
+            end
+        end
+    end)
+end
+
+-- Public methods.
+local method = {}
+
+-- Initialise queue states. Must be called on queue starts.
+function method.init(tubes)
+    current = queue_state.states.RUNNING
+    create_state_fiber(tubes)
+end
+
+-- Show current state in human readable format.
+function method.show()
+    return get_state_key(current)
+end
+
+-- Get current state.
+function method.get()
+    return current
+end
+
+-- Polls queue state with maximum attemps number.
+function method.poll(state, max_attempts)
+    local attempt = 0
+    while true do
+        if current == state then
+            return true
+        end
+        attempt = attempt + 1
+        if attempt == max_attempts then
+            break
+        end
+        fiber.sleep(0.01)
+    end
+
+    return false
+end
+
+return setmetatable(queue_state, { __index = method })

--- a/queue/abstract/queue_state.lua
+++ b/queue/abstract/queue_state.lua
@@ -44,8 +44,9 @@ end
 
 local function max_lag()
     local max_lag = 0
+    local n_replica = table.maxn(box.info.replication)
 
-    for i = 1, #box.info.replication do
+    for i = 1, n_replica do
         if box.info.replication[i].upstream then
             local lag = box.info.replication[i].upstream.lag
             if lag > max_lag then

--- a/queue/init.lua
+++ b/queue/init.lua
@@ -95,8 +95,8 @@ function wrapper_impl(...)
         -- Now the "register_driver" method from abstract will be used.
         queue.register_driver = nil
         setmetatable(queue, getmetatable(abstract))
-        queue.start()
         queue.cfg(deferred_opts)
+        queue.start()
     else
         -- Delay a start until the box will be configured
         -- with read_only = false

--- a/t/020-fifottl.t
+++ b/t/020-fifottl.t
@@ -6,6 +6,7 @@ test:plan(16)
 
 local queue = require('queue')
 local state = require('queue.abstract.state')
+local queue_state = require('queue.abstract.queue_state')
 
 local qc = require('queue.compat')
 
@@ -209,10 +210,18 @@ test:test('touch test', function(test)
 end)
 
 test:test('read_only test', function(test)
-    test:plan(4)
+    test:plan(7)
     tube:put('abc', { delay = 0.1 })
+    local ttl_fiber = tube.raw.fiber
     box.cfg{ read_only = true }
+    -- Wait for a change in the state of the queue to waiting no more than 10 seconds.
+    local rc = queue_state.poll(queue_state.states.WAITING, 10)
+    test:ok(rc, "queue state changed to waiting")
     fiber.sleep(0.11)
+    test:is(ttl_fiber:status(), 'dead',
+        "check that background fiber is canceled")
+    test:isnil(tube.raw.fiber,
+            "check that background fiber object is cleaned")
     if qc.check_version({1, 7}) then
         local task = tube:take(0.2)
         test:isnil(task, "check that task wasn't moved to ready state")
@@ -220,11 +229,11 @@ test:test('read_only test', function(test)
         local stat, task = pcall(tube.take, tube, 0.2)
         test:is(stat, false, "check that task wasn't taken")
     end
-    test:is(tube.raw.fiber:status(), 'suspended',
-            "check that background fiber isn't dead")
     box.cfg{ read_only = false }
+    local rc = queue_state.poll(queue_state.states.RUNNING, 10)
+    test:ok(rc, "queue state changed to running")
     test:is(tube.raw.fiber:status(), 'suspended',
-            "check that background fiber isn't dead again")
+            "check that background fiber started")
     local task = tube:take()
     test:isnt(task, nil, "check that we can take task")
     tube:ack(task[1])

--- a/t/200-master-replica.t
+++ b/t/200-master-replica.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env tarantool
 
 local fio   = require('fio')
+local log   = require('log')
 local tnt   = require('t.tnt')
 local test  = require('tap').test('')
 local uuid  = require('uuid')
@@ -11,7 +12,13 @@ local session  = require('queue.abstract.queue_session')
 local queue_state = require('queue.abstract.queue_state')
 rawset(_G, 'queue', require('queue'))
 
--- Replica connection handler
+local qc = require('queue.compat')
+if not qc.check_version({2, 4, 1}) then
+    log.info('Tests skipped, tarantool version < 2.4.1')
+    return
+end
+
+-- Replica connection handler.
 local conn = {}
 
 test:plan(5)

--- a/t/200-master-replica.t
+++ b/t/200-master-replica.t
@@ -21,7 +21,7 @@ end
 -- Replica connection handler.
 local conn = {}
 
-test:plan(6)
+test:plan(7)
 
 test:test('Check master-replica setup', function(test)
     test:plan(8)
@@ -61,7 +61,7 @@ test:test('Check queue state switching', function(test)
 end)
 
 test:test('Check session resuming', function(test)
-    test:plan(17)
+    test:plan(16)
     local client = tnt.cluster.connect_master()
     test:ok(client.error == nil, 'no errors on client connect to master')
     local session_uuid = client:call('queue.identify')
@@ -71,30 +71,10 @@ test:test('Check session resuming', function(test)
     local task_master = client:call('queue.tube.test:take')
     test:ok(task_master, 'task was taken')
     test:is(task_master[3], 'testdata', 'task.data')
-    client:close()
 
     local qt = box.space._queue_taken_2:select()
     test:is(uuid.frombin(qt[1][4]):str(), uuid_obj:str(),
         'task taken by actual uuid')
-
-    -- Wait for disconnect callback.
-    local attempts = 0
-    while true do
-        local is = box.space._queue_inactive_sessions:select()
-
-        if is[1] then
-            test:is(uuid.frombin(is[1][1]):str(), uuid_obj:str(),
-                'check inactive sessions')
-            break
-        end
-
-        attempts = attempts + 1
-        if attempts == 10 then
-            test:ok(false, 'check inactive sessions')
-            return false
-        end
-        fiber.sleep(0.01)
-    end
 
     -- Switch roles.
     box.cfg{read_only = true}
@@ -130,9 +110,122 @@ test:test('Check session resuming', function(test)
     queue_state.poll(queue_state.states.RUNNING, 10)
     test:is(queue.state(), 'RUNNING', 'master state is running')
     test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
+    client:close()
+end)
+
+test:test('Check session resuming (client disconnected)', function(test)
+    test:plan(17)
+    local client = tnt.cluster.connect_master()
+    test:ok(client.error == nil, 'no errors on client connect to master')
+    local session_uuid = client:call('queue.identify')
+    local uuid_obj = uuid.frombin(session_uuid)
+
+    test:ok(queue.tube.test:put('testdata'), 'put task')
+    local task_master = client:call('queue.tube.test:take')
+    test:ok(task_master, 'task was taken')
+    test:is(task_master[3], 'testdata', 'task.data')
+    client:close()
+
+    local qt = box.space._queue_taken_2:select()
+    test:is(uuid.frombin(qt[1][4]):str(), uuid_obj:str(),
+        'task taken by actual uuid')
+
+    -- Wait for disconnect callback.
+    local attempts = 0
+    while true do
+        local tuple = box.space._queue_shared_sessions:get(session_uuid)
+
+        if tuple then
+            test:is(uuid.frombin(tuple[1]):str(), uuid_obj:str(),
+                'check inactive sessions')
+            break
+        end
+
+        attempts = attempts + 1
+        if attempts == 10 then
+            test:ok(false, 'check inactive sessions')
+            return false
+        end
+        fiber.sleep(0.01)
+    end
+
+    -- Switch roles.
+    box.cfg{read_only = true}
+    queue_state.poll(queue_state.states.WAITING, 10)
+    test:is(queue.state(), 'WAITING', 'master state is waiting')
+    conn:eval('box.cfg{read_only=false}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.RUNNING, 10)
+    ]])
+    test:is(conn:call('queue.state'), 'RUNNING', 'replica state is running')
+
+    local cfg = conn:eval('return queue.cfg')
+    test:is(cfg.ttr, 0.5, 'check cfg applied after lazy start')
+
+    test:ok(conn:call('queue.identify', {session_uuid}), 'identify old session')
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 1, 'taken tasks count')
+    test:is(stat.test.tasks.done, 1, 'done tasks count')
+    local task_replica = conn:call('queue.tube.test:ack', {task_master[1]})
+    test:is(task_replica[3], 'testdata', 'check task data')
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 0, 'taken tasks count after ack()')
+    test:is(stat.test.tasks.done, 2, 'done tasks count after ack()')
+
+    -- Switch roles back.
+    conn:eval('box.cfg{read_only=true}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.WAITING, 10)
+    ]])
+    box.cfg{read_only = false}
+    queue_state.poll(queue_state.states.RUNNING, 10)
+    test:is(queue.state(), 'RUNNING', 'master state is running')
+    test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
 end)
 
 test:test('Check task is cleaned after migrate', function(test)
+    test:plan(8)
+    local client = tnt.cluster.connect_master()
+    local session_uuid = client:call('queue.identify')
+    local uuid_obj = uuid.frombin(session_uuid)
+    test:ok(queue.tube.test:put('testdata'), 'put task')
+    test:ok(client:call('queue.tube.test:take'), 'take task from master')
+
+    -- Switch roles.
+    box.cfg{read_only = true}
+
+    queue_state.poll(queue_state.states.WAITING, 10)
+    test:is(queue.state(), 'WAITING', 'master state is waiting')
+    conn:eval('box.cfg{read_only=false}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.RUNNING, 10)
+    ]])
+    test:is(conn:call('queue.state'), 'RUNNING', 'replica state is running')
+
+    -- Check task.
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 1, 'taken tasks count before timeout')
+    fiber.sleep(1.5)
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 0, 'taken tasks count after timeout')
+
+    -- Switch roles back.
+    conn:eval('box.cfg{read_only=true}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.WAITING, 10)
+    ]])
+    box.cfg{read_only = false}
+    queue_state.poll(queue_state.states.RUNNING, 10)
+    test:is(queue.state(), 'RUNNING', 'master state is running')
+    test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
+    client:close()
+end)
+
+test:test('Check task is cleaned after migrate (client disconnected)', function(test)
     test:plan(9)
     local client = tnt.cluster.connect_master()
     local session_uuid = client:call('queue.identify')
@@ -144,10 +237,10 @@ test:test('Check task is cleaned after migrate', function(test)
     -- Wait for disconnect callback.
     local attempts = 0
     while true do
-        local is = box.space._queue_inactive_sessions:select()
+        local tuple = box.space._queue_shared_sessions:get(session_uuid)
 
-        if is[1] then
-            test:is(uuid.frombin(is[1][1]):str(), uuid_obj:str(),
+        if tuple then
+            test:is(uuid.frombin(tuple[1]):str(), uuid_obj:str(),
                 'check inactive sessions')
             break
         end
@@ -191,31 +284,18 @@ test:test('Check task is cleaned after migrate', function(test)
     test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
 end)
 
-test:test('Check release_all method', function(test)
-    test:plan(6)
-    test:ok(queue.tube.test:put('testdata'), 'put task #0')
-    test:ok(queue.tube.test:put('testdata'), 'put task #1')
-    test:ok(queue.tube.test:take(), 'take task #0')
-    test:ok(queue.tube.test:take(), 'take task #1')
-    test:is(queue.statistics().test.tasks.taken, 2,
-        'taken tasks count before release_all')
-    queue.tube.test:release_all()
-    test:is(queue.statistics().test.tasks.taken, 0,
-        'taken tasks count after release_all')
-end)
-
 test:test('Check in_replicaset switching', function(test)
-    test:plan(15)
+    test:plan(17)
     test:ok(queue.tube.test:put('testdata0'), 'put task #0')
     test:ok(queue.tube.test:put('testdata1'), 'put task #1')
-    test:ok(queue.tube.test:take(), 'take task')
     local client = tnt.cluster.connect_master()
+    test:ok(client:call('queue.tube.test:take'), 'take task')
     test:ok(client:call('queue.tube.test:take'), 'take task')
     client:close()
     -- Wait for disconnect callback.
     local attempts = 0
     while true do
-        if #box.space._queue_inactive_sessions:select() == 1 then
+        if #box.space._queue_shared_sessions:select() == 1 then
             break
         end
 
@@ -226,30 +306,35 @@ test:test('Check in_replicaset switching', function(test)
         end
         fiber.sleep(0.01)
     end
-    test:is(box.space._queue_inactive_sessions.temporary, false,
-        '_queue_inactive_sessions is not temporary')
+    test:is(box.space._queue_shared_sessions.temporary, false,
+        '_queue_shared_sessions is not temporary')
     test:is(box.space._queue_taken_2.temporary, false,
         '_queue_taken_2 is not temporary')
     test:is(#box.space._queue_taken_2:select(), 2,
         'check _queue_taken_2 data')
     queue.cfg{in_replicaset = false}
-    test:is(box.space._queue_inactive_sessions.temporary, true,
-        '_queue_inactive_sessions is temporary')
+    test:is(box.space._queue_shared_sessions.temporary, true,
+        '_queue_shared_sessions is temporary')
     test:is(box.space._queue_taken_2.temporary, true,
         '_queue_taken_2 is temporary')
     test:is(#box.space._queue_taken_2:select(), 2,
         'check _queue_taken_2 data')
-    test:is(#box.space._queue_inactive_sessions:select(), 1,
-        'check _queue_inactive_sessions data')
+    test:is(#box.space._queue_shared_sessions:select(), 1,
+        'check _queue_shared_sessions data')
     queue.cfg{in_replicaset = true}
-    test:is(box.space._queue_inactive_sessions.temporary, false,
-        '_queue_inactive_sessions is not temporary')
+    test:is(box.space._queue_shared_sessions.temporary, false,
+        '_queue_shared_sessions is not temporary')
     test:is(box.space._queue_taken_2.temporary, false,
         '_queue_taken_2 is not temporary')
     test:is(#box.space._queue_taken_2:select(), 2,
         'check _queue_taken_2 data')
-    test:is(#box.space._queue_inactive_sessions:select(), 1,
-        'check _queue_inactive_sessions data')
+    test:is(#box.space._queue_shared_sessions:select(), 1,
+        'check _queue_shared_sessions data')
+    test:is(queue.statistics().test.tasks.taken, 2,
+        'taken tasks count before release_all')
+    queue.tube.test:release_all()
+    test:is(queue.statistics().test.tasks.taken, 0,
+        'taken tasks count after release_all')
 end)
 
 rawset(_G, 'queue', nil)

--- a/t/200-master-replica.t
+++ b/t/200-master-replica.t
@@ -1,0 +1,205 @@
+#!/usr/bin/env tarantool
+
+local fio   = require('fio')
+local tnt   = require('t.tnt')
+local test  = require('tap').test('')
+local uuid  = require('uuid')
+local queue = require('queue')
+local fiber = require('fiber')
+
+local session  = require('queue.abstract.queue_session')
+local queue_state = require('queue.abstract.queue_state')
+rawset(_G, 'queue', require('queue'))
+
+-- Replica connection handler
+local conn = {}
+
+test:plan(5)
+
+test:test('Check master-replica setup', function(test)
+    test:plan(8)
+    local engine = os.getenv('ENGINE') or 'memtx'
+    tnt.cluster.cfg{}
+
+    test:ok(rawget(box, 'space'), 'box started')
+    test:ok(queue, 'queue is loaded')
+
+    test:ok(tnt.cluster.wait_replica(), 'wait for replica to connect')
+    conn = tnt.cluster.connect_replica()
+    test:ok(conn.error == nil, 'no errors on connect to replica')
+    test:ok(conn:ping(), 'ping replica')
+    test:is(queue.state(), 'RUNNING', 'check master queue state')
+    conn:eval('rawset(_G, "queue", require("queue"))')
+    test:is(conn:call('queue.state'), 'INIT', 'check replica queue state')
+
+    -- Setup tube. Set ttr = 0.5 for sessions expire testing.
+    conn:call('queue.cfg', {{ttr = 0.5}})
+    queue.cfg{ttr = 0.5}
+    local tube = queue.create_tube('test', 'fifo', {engine = engine})
+    test:ok(tube, 'test tube created')
+end)
+
+test:test('Check queue state switching', function(test)
+    test:plan(4)
+    box.cfg{read_only = true}
+    test:ok(queue_state.poll(queue_state.states.WAITING, 10),
+        "queue state changed to waiting")
+    test:is(session.expiration_fiber:status(), 'dead',
+        "check that session expiration fiber is canceled")
+    box.cfg{read_only = false}
+    test:ok(queue_state.poll(queue_state.states.RUNNING, 10),
+        "queue state changed to running")
+    test:is(session.expiration_fiber:status(), 'suspended',
+            "check that session expiration fiber started")
+end)
+
+test:test('Check session resuming', function(test)
+    test:plan(17)
+    local client = tnt.cluster.connect_master()
+    test:ok(client.error == nil, 'no errors on client connect to master')
+    local session_uuid = client:call('queue.identify')
+    local uuid_obj = uuid.frombin(session_uuid)
+
+    test:ok(queue.tube.test:put('testdata'), 'put task')
+    local task_master = client:call('queue.tube.test:take')
+    test:ok(task_master, 'task was taken')
+    test:is(task_master[3], 'testdata', 'task.data')
+    client:close()
+
+    local qt = box.space._queue_taken_2:select()
+    test:is(uuid.frombin(qt[1][4]):str(), uuid_obj:str(),
+        'task taken by actual uuid')
+
+    -- Wait for disconnect callback.
+    local attempts = 0
+    while true do
+        local is = box.space._queue_inactive_sessions:select()
+
+        if is[1] then
+            test:is(uuid.frombin(is[1][1]):str(), uuid_obj:str(),
+                'check inactive sessions')
+            break
+        end
+
+        attempts = attempts + 1
+        if attempts == 10 then
+            test:ok(false, 'check inactive sessions')
+            return false
+        end
+        fiber.sleep(0.01)
+    end
+
+    -- Switch roles.
+    box.cfg{read_only = true}
+    queue_state.poll(queue_state.states.WAITING, 10)
+    test:is(queue.state(), 'WAITING', 'master state is waiting')
+    conn:eval('box.cfg{read_only=false}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.RUNNING, 10)
+    ]])
+    test:is(conn:call('queue.state'), 'RUNNING', 'replica state is running')
+
+    local cfg = conn:eval('return queue.cfg')
+    test:is(cfg.ttr, 0.5, 'check cfg applied after lazy start')
+
+    test:ok(conn:call('queue.identify', {session_uuid}), 'identify old session')
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 1, 'taken tasks count')
+    test:is(stat.test.tasks.done, 0, 'done tasks count')
+    local task_replica = conn:call('queue.tube.test:ack', {task_master[1]})
+    test:is(task_replica[3], 'testdata', 'check task data')
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 0, 'taken tasks count after ack()')
+    test:is(stat.test.tasks.done, 1, 'done tasks count after ack()')
+
+    -- Switch roles back.
+    conn:eval('box.cfg{read_only=true}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.WAITING, 10)
+    ]])
+    box.cfg{read_only = false}
+    queue_state.poll(queue_state.states.RUNNING, 10)
+    test:is(queue.state(), 'RUNNING', 'master state is running')
+    test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
+end)
+
+test:test('Check task is cleaned after migrate', function(test)
+    test:plan(9)
+    local client = tnt.cluster.connect_master()
+    local session_uuid = client:call('queue.identify')
+    local uuid_obj = uuid.frombin(session_uuid)
+    test:ok(queue.tube.test:put('testdata'), 'put task')
+    test:ok(client:call('queue.tube.test:take'), 'take task from master')
+    client:close()
+
+    -- Wait for disconnect callback.
+    local attempts = 0
+    while true do
+        local is = box.space._queue_inactive_sessions:select()
+
+        if is[1] then
+            test:is(uuid.frombin(is[1][1]):str(), uuid_obj:str(),
+                'check inactive sessions')
+            break
+        end
+
+        attempts = attempts + 1
+        if attempts == 10 then
+            test:ok(false, 'check inactive sessions')
+            return false
+        end
+        fiber.sleep(0.01)
+    end
+
+    -- Switch roles.
+    box.cfg{read_only = true}
+
+    queue_state.poll(queue_state.states.WAITING, 10)
+    test:is(queue.state(), 'WAITING', 'master state is waiting')
+    conn:eval('box.cfg{read_only=false}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.RUNNING, 10)
+    ]])
+    test:is(conn:call('queue.state'), 'RUNNING', 'replica state is running')
+
+    -- Check task.
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 1, 'taken tasks count before timeout')
+    fiber.sleep(1.5)
+    local stat = conn:call('queue.statistics')
+    test:is(stat.test.tasks.taken, 0, 'taken tasks count after timeout')
+
+    -- Switch roles back.
+    conn:eval('box.cfg{read_only=true}')
+    conn:eval([[
+        queue_state = require('queue.abstract.queue_state')
+        queue_state.poll(queue_state.states.WAITING, 10)
+    ]])
+    box.cfg{read_only = false}
+    queue_state.poll(queue_state.states.RUNNING, 10)
+    test:is(queue.state(), 'RUNNING', 'master state is running')
+    test:is(conn:call('queue.state'), 'WAITING', 'replica state is waiting')
+end)
+
+test:test('Check release_all method', function(test)
+    test:plan(6)
+    test:ok(queue.tube.test:put('testdata'), 'put task #0')
+    test:ok(queue.tube.test:put('testdata'), 'put task #1')
+    test:ok(queue.tube.test:take(), 'take task #0')
+    test:ok(queue.tube.test:take(), 'take task #1')
+    test:is(queue.statistics().test.tasks.taken, 2,
+        'taken tasks count before release_all')
+    queue.tube.test:release_all()
+    test:is(queue.statistics().test.tasks.taken, 0,
+        'taken tasks count after release_all')
+end)
+
+rawset(_G, 'queue', nil)
+conn:eval('rawset(_G, "queue", nil)')
+conn:close()
+tnt.finish()
+os.exit(test:check() and 0 or 1)
+-- vim: set ft=lua :

--- a/t/tnt/init.lua
+++ b/t/tnt/init.lua
@@ -2,6 +2,9 @@ local fio   = require('fio')
 local log   = require('log')
 local yaml  = require('yaml')
 local errno = require('errno')
+local fiber  = require('fiber')
+local popen  = require('popen')
+local netbox = require('net.box')
 
 local dir     = os.getenv('QUEUE_TMP')
 local cleanup = false
@@ -10,6 +13,19 @@ local qc              = require('queue.compat')
 local vinyl_name      = qc.vinyl_name
 local snapdir_optname = qc.snapdir_optname
 local logger_optname  = qc.logger_optname
+
+local bind_master  = os.getenv('QUEUE_MASTER_ADDR')
+local bind_replica = os.getenv('QUEUE_REPLICA_ADDR')
+local dir_replica  = nil
+local replica      = nil
+
+if bind_master == nil then
+    bind_master = '127.0.0.1:3398'
+end
+
+if bind_replica == nil then
+    bind_replica = '127.0.0.1:3399'
+end
 
 if dir == nil then
     dir = fio.tempdir()
@@ -37,6 +53,116 @@ local function tnt_prepare(cfg_args)
     box.cfg(cfg_args)
 end
 
+-- Creates master and replica setup for queue states switching tests.
+local function tnt_cluster_prepare(cfg_args)
+    -- Prepare master.
+    cfg_args = cfg_args or {}
+    local files = fio.glob(fio.pathjoin(dir, '*'))
+    for _, file in pairs(files) do
+        if fio.basename(file) ~= 'tarantool.log' then
+            log.info("skip removing %s", file)
+            fio.unlink(file)
+        end
+    end
+
+    cfg_args['wal_dir']         = dir
+    cfg_args['read_only']       = false
+    cfg_args[snapdir_optname()] = dir
+    cfg_args[logger_optname()]  = fio.pathjoin(dir, 'tarantool.log')
+    cfg_args['listen']          = bind_master
+    cfg_args['replication']     = {'replicator:password@' .. bind_replica,
+                                   'replicator:password@' .. bind_master}
+    if vinyl_name() then
+        local vinyl_optname     = vinyl_name() .. '_dir'
+        cfg_args[vinyl_optname] = dir
+    end
+    cfg_args['replication_connect_quorum']  = 1
+    cfg_args['replication_connect_timeout'] = 0.01
+
+    box.cfg(cfg_args)
+    -- Allow guest all operations.
+    box.schema.user.grant('guest', 'read, write, execute', 'universe')
+    box.schema.user.create('replicator', {password = 'password'})
+    box.schema.user.grant('replicator', 'replication')
+
+    -- Prepare replica.
+    dir_replica = fio.tempdir()
+
+    local vinyl_opt = nil
+    if vinyl_name() then
+        vinyl_opt = ', ' .. vinyl_name() .. '_dir = \'' .. dir_replica .. '\''
+    else
+        vinyl_opt = ''
+    end
+
+    local cmd_replica = {
+        arg[-1],
+        '-e',
+        [[
+        box.cfg {
+            read_only = true,
+            replication = 'replicator:password@]] .. bind_master ..
+            '\', listen = \'' .. bind_replica ..
+            '\', wal_dir = \'' .. dir_replica ..
+            '\', ' .. snapdir_optname() .. ' = \'' .. dir_replica ..
+            '\', ' .. logger_optname() .. ' = \'' ..
+            fio.pathjoin(dir_replica, 'tarantool.log') .. '\'' ..
+            vinyl_opt ..
+        '}'
+    }
+
+    replica = popen.new(cmd_replica, {
+        stdin = 'devnull',
+        stdout = 'devnull',
+        stderr = 'devnull',
+    })
+
+    -- Wait for replica to connect.
+    local id = (box.info.replication[1].uuid ~= box.info.uuid and 1) or 2
+    local attempts = 0
+
+    while true do
+        if #box.info.replication == 2 and box.info.replication[id].upstream then
+            break
+        end
+        attempts = attempts + 1
+        if attempts == 30 then
+            error('wait for replica failed')
+        end
+        fiber.sleep(0.1)
+    end
+end
+
+local function connect_replica()
+    if not replica then
+        return nil
+    end
+
+    return netbox.connect(bind_replica)
+end
+
+local function connect_master()
+    return netbox.connect(bind_master)
+end
+
+-- Wait for replica to connect.
+local function wait_replica()
+    local attempts = 0
+
+    while true do
+        if #box.info.replication == 2 then
+            return true
+        end
+        attempts = attempts + 1
+        if attempts == 10 then
+            return false
+        end
+        fiber.sleep(0.1)
+    end
+
+    return false
+end
+
 return {
     finish = function(code)
         local files = fio.glob(fio.pathjoin(dir, '*'))
@@ -51,6 +177,17 @@ return {
         if cleanup then
             log.info("rmdir %s", dir)
             fio.rmdir(dir)
+        end
+        if dir_replica then
+            local files = fio.glob(fio.pathjoin(dir, '*'))
+            for _, file in pairs(files) do
+                log.info("remove %s", file)
+                fio.unlink(file)
+            end
+        end
+        if replica then
+            replica:kill()
+            replica:wait()
         end
     end,
 
@@ -77,5 +214,11 @@ return {
         return data
     end,
 
-    cfg = tnt_prepare
+    cfg = tnt_prepare,
+    cluster = {
+        cfg = tnt_cluster_prepare,
+        wait_replica = wait_replica,
+        connect_replica = connect_replica,
+        connect_master = connect_master
+    }
 }

--- a/t/tnt/init.lua
+++ b/t/tnt/init.lua
@@ -3,7 +3,6 @@ local log   = require('log')
 local yaml  = require('yaml')
 local errno = require('errno')
 local fiber  = require('fiber')
-local popen  = require('popen')
 local netbox = require('net.box')
 
 local dir     = os.getenv('QUEUE_TMP')
@@ -55,6 +54,13 @@ end
 
 -- Creates master and replica setup for queue states switching tests.
 local function tnt_cluster_prepare(cfg_args)
+    -- Since version 2.4.1, Tarantool has the popen built-in module
+    -- that supports execution of external programs.
+    if not qc.check_version({2, 4, 1}) then
+        error('this test requires tarantool >= 2.4.1')
+        return false
+    end
+
     -- Prepare master.
     cfg_args = cfg_args or {}
     local files = fio.glob(fio.pathjoin(dir, '*'))
@@ -111,7 +117,7 @@ local function tnt_cluster_prepare(cfg_args)
         '}'
     }
 
-    replica = popen.new(cmd_replica, {
+    replica = require('popen').new(cmd_replica, {
         stdin = 'devnull',
         stdout = 'devnull',
         stderr = 'devnull',


### PR DESCRIPTION
This patch adds ability to use queue in a master-replica scheme.
The queue will monitor the operation mode of the tarantool and
perform the necessary actions accordingly.

This patch adds five states for queue: INIT, STARTUP, RUNNING, ENDING
and WAITING. When the tarantool is launched for the first time,
the state of the queue is always INIT until box.info.ro is false.

States switching scheme:
```mermaid
stateDiagram-v2
direction LR
w: Waiting
note right of w
  monitor rw status
end note
s: Startup
note left of s
  wait for maximum
  upstream lag * 2
  release all tasks
  start driver
end note
Init --> s
r: Running
note right of r
  queue is ready
end note
e: Ending
note left of e
  stop driver
end note
w --> s: ro -> rw
s --> r
r --> e: rw -> ro
e --> w
```

In the STARTUP state, the queue is waiting for possible data synchronization
with other cluster members by the time of the largest upstream lag multiplied
by two. After that, all taken tasks are released, except for tasks with
session uuid matching inactive sessions uuids. This makes possible to take
a task, switch roles on the cluster, and release the task within the timeout
specified by the queue.cfg({ttr = N}) parameter. Note: all clients that take()
and do not ack()/release() tasks must be disconnected before changing the role.
And the last step in the STARTUP state is starting tube driver using new
method called start(). Each tube driver must implement start() and stop()
methods. The start() method should start the driver fibers, if any, in other
words, initialize all asynchronous work with the tubes space. The stop()
methods shuld stop the driver fibers, if any, respectively.

In the RUNNING state, the queue is working as usually. The ENDING state calls
stop() method. in the WAITING state, the queue listens for a change in the
read_only flag.

All states except INIT is controlled by new fiber called 'queue_state_fiber'.

A new release_all() method has also been added, which forcibly returns all
taken tasks to a ready state. This method can be called per tube.

Closes #120
