### PR TITLE
Update the list of repositories for the module deployment

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Deploy packages
         env:
-          RWS_URL_PART: https://rws.tarantool.org/release/enabled
+          RWS_URL_PART: https://rws.tarantool.org/tarantool-modules
           RWS_AUTH: ${{ secrets.RWS_AUTH }}
           PRODUCT_NAME: tarantool-queue
         run: |


### PR DESCRIPTION
After the patch, old "live" repositories will be included in the deployment list.

Closes #158