### PR TITLE
readme: fix `Table of contents` title

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ align="right">
 </a>
 
 # A collection of persistent queue implementations for Tarantool
-#Table of contents
+
+## Table of contents
 
 * [Queue types](#queue-types)
   * [fifo \- a simple queue](#fifo---a-simple-queue)


### PR DESCRIPTION
The patch fixes markdown of `Table of contents` title.

Before and after the fix:
![contents](https://user-images.githubusercontent.com/29621138/184081453-8b4bb31c-45c4-4e52-bdea-9781e345401d.png)

