### PR TITLE
cd: downgrade a runner image to ubuntu-18.04

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -9,7 +9,9 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
+    # Packaging for CentOS 7 does not work with other versions, see:
+    # https://github.com/packpack/packpack/issues/145
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Due to a bug [1], packaging for Centos 7 does not work on ubuntu-latest. We need to downgrade a GitHub Actions runner image version until the problem is fixed.

1. https://github.com/packpack/packpack/issues/145