### PR TITLE
abstract: reduced increased CPU consumption

### DIFF
--- a/queue/abstract/queue_state.lua
+++ b/queue/abstract/queue_state.lua
@@ -65,7 +65,7 @@ local function create_state_fiber(on_state_change_cb)
         fiber.self():name('queue_state_fiber')
         while true do
             if current == queue_state.states.WAITING then
-                local rc = pcall(box.ctl.wait_rw, 0.001)
+                local rc = pcall(box.ctl.wait_rw)
                 if rc then
                     current = queue_state.states.STARTUP
                     log.info('Queue state changed: STARTUP')
@@ -76,7 +76,7 @@ local function create_state_fiber(on_state_change_cb)
                     log.info('Queue state changed: RUNNING')
                 end
             elseif current == queue_state.states.RUNNING then
-                local rc = pcall(box.ctl.wait_ro, 0.001)
+                local rc = pcall(box.ctl.wait_ro)
                 if rc then
                     current = queue_state.states.ENDING
                     on_state_change_cb(current)


### PR DESCRIPTION
Due to the fact that queue_state_fiber called box.ctrl.wait_r* every millisecond, the idle queue consumed more than 10% of CPU.

The proposed solution makes calls to box.ctrl.wait_r* blocking until the read/write mode is changed.
`Thus, CPU consumption is reduced to about ~1%.`

Below is a performance comparison using a script `t/benchmark/multi_consumer_work.lua` whith params consumers-count = 650 and batch-size = 5000 on CPU AMD Ryzen 5 5600U.

For comparison, consider three commits.
The first column is commit (9ff105b) before implementing queue_state_fiber.
The second column is commit (159a43d) before implementation of the described proposal. That is, queue_state_fiber calls box.ctrl.wait_r* every millisecond. 
The third column (offered) is the current offer, the box.ctrl.wait_r* blocking call.

The data is given as an arithmetic mean of 25 measurement points:

| [time\commit] | 9ff105b    | 159a43d    | offered    |
|--------------|------------------|------------------|------------------|
| fill queue    | 8 197 452  | 8 567 415  | 8 751 545  |
| task confirm  | 49 817 371 | 52 203 080 | 53 020 243 |

Final performance comparison as a percentage:

| % down       | 9ff105b->159a43d | 159a43d->offered | 9ff105b->offered | 
|--------------|------------------|------------------|------------------|
| fill queue   | 4.513% down      | 2.149% down      | 6.759% down      |
| task confirm | 4.788% down      | 1.565% down      | 6.429% down      | 


`As a result, the proposed solution causes a decrease in performance for fill queue 2.149% and task confirm 1.565%.`

Closes #183