### PR TITLE
Remove printing secrets to the log

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -77,10 +77,18 @@ jobs:
             -u ${RWS_AUTH} \
             -F product=${PRODUCT_NAME}"
 
+          # We don't want to try to print secrets to the log, but we want
+          # to print a "curl" command to see what's going on.
+          CURL_CMD_ECHO="curl -LfsS \
+            -X PUT ${RWS_URL_PART}/${OS}/${DIST} \
+            -u *** \
+            -F product=${PRODUCT_NAME}"
+
           for f in $(ls -I '*build*' -I '*.changes' ./build); do
             CURL_CMD+=" -F $(basename ${f})=@./build/${f}"
+            CURL_CMD_ECHO+=" -F $(basename ${f})=@./build/${f}"
           done
 
-          echo ${CURL_CMD}
+          echo ${CURL_CMD_ECHO}
 
           ${CURL_CMD}


### PR DESCRIPTION
According to [1] printing secrets to the log is not a best practice.

[1] https://docs.github.com/en/actions/security-guides/encrypted-secrets#accessing-your-secrets