### PR TITLE
cd: fix rockspec publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
       - uses: tarantool/setup-tarantool@v1
         with:
-          tarantool-version: '1.10'
+          tarantool-version: '2.10'
       - run: tarantoolctl rocks install queue-${{ env.TAG }}-1.rockspec
       - run: tarantoolctl rocks pack queue ${{ env.TAG }}
 


### PR DESCRIPTION
The problem is that on Ubuntu 22.04 luarocks v3 from the `tarantool-common` package is installed, but tarantoolctl from tarantool 1.10 uses luarocks v2.
See [1] for more details.

[1] https://github.com/tarantool/tarantool/issues/5429#issuecomment-1336162554