### PR TITLE
ci: remove deprecated option from utils

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -19,7 +19,7 @@ jobs:
         tarantool:
           - '1.10'
           - '2.8'
-          - '2.9'
+          - '2.10'
 
     steps:
       - name: Clone the module


### PR DESCRIPTION
Deprecated `replication_connect_quorum` option was removed from replicaset setup method.