### PR TITLE
abstract: make fibers cancellable

### DIFF
--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -169,7 +169,7 @@ local function utubettl_fiber(self)
         if box.info.ro == false then
             local stat, err = pcall(utubettl_fiber_iteration, self, processed)
 
-            if not stat and not err.code == box.error.READONLY then
+            if not stat and not (err.code == box.error.READONLY) then
                 log.error("error catched: %s", tostring(err))
                 log.error("exiting fiber '%s'", fiber.name())
                 return 1

--- a/queue/abstract/queue_state.lua
+++ b/queue/abstract/queue_state.lua
@@ -85,8 +85,14 @@ local function create_state_fiber(on_state_change_cb)
                     log.info('Queue state changed: WAITING')
                 end
             end
+            -- Handle server shutdown.
+            if not pcall(fiber.testcancel) then
+                break
+            end
         end
     end)
+
+    log.info('Finished queue state fiber')
 end
 
 -- Public methods.


### PR DESCRIPTION
We are going to finish all client (non-system) fibers in the process of Tarantool shutdown. First we cancel them and then wait for their finishing. So if the client fibers are not finished Tarantool shutdown is never finished too.

Currently some of queue fibers can not be finished and we got hang on integration testing of PR [1]. Let's fix it.

[1] PR with client fibers finishing on shutdown.
https://github.com/tarantool/tarantool/pull/9604