### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
 ### Fixed
 
-- Too long timings in the `utubettl` driver (#223)
+## [1.4.1] - 2024-05-21
+
+The release fixes too long release time by a `ttr` value or a `delay` timeout.
+
+### Fixed
+
+- Too long timings in the `utubettl` driver (#223).
 
 ## [1.4.0] - 2024-05-20
 

--- a/queue/version.lua
+++ b/queue/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.0'
+return '1.4.1'


### PR DESCRIPTION
The release fixes too long release time by a `ttr` value or a `delay` timeout.

### Fixed

- Too long timings in the `utubettl` driver (#223).