### PR TITLE
drivers: add grant method for all driver spaces

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Grant method was added for `*_ready_buffer` spaces (#237).
+
 ## [1.4.2] - 2024-08-10
 
 The release re-publish packages.

--- a/queue/abstract.lua
+++ b/queue/abstract.lua
@@ -346,7 +346,7 @@ function tube.grant(self, user, args)
     tube_grant_space(user, '_queue', 'read')
     tube_grant_space(user, '_queue_consumers')
     tube_grant_space(user, '_queue_taken_2')
-    tube_grant_space(user, self.name)
+    self.raw:grant(user, {if_not_exists = true})
     session.grant(user)
 
     if args.call then

--- a/queue/abstract/driver/fifo.lua
+++ b/queue/abstract/driver/fifo.lua
@@ -61,6 +61,11 @@ function tube.new(space, on_task_change)
     return self
 end
 
+-- method.grant grants provided user to all spaces of driver.
+function method.grant(self, user, opts)
+    box.schema.user.grant(user, 'read,write', 'space', self.space.name, opts)
+end
+
 -- normalize task: cleanup all internal fields
 function method.normalize_task(self, task)
     return task

--- a/queue/abstract/driver/fifottl.lua
+++ b/queue/abstract/driver/fifottl.lua
@@ -202,6 +202,11 @@ function tube.new(space, on_task_change, opts)
     return self
 end
 
+-- method.grant grants provided user to all spaces of driver.
+function method.grant(self, user, opts)
+    box.schema.user.grant(user, 'read,write', 'space', self.space.name, opts)
+end
+
 -- cleanup internal fields in task
 function method.normalize_task(self, task)
     return task and task:transform(3, 5)

--- a/queue/abstract/driver/utube.lua
+++ b/queue/abstract/driver/utube.lua
@@ -126,6 +126,14 @@ function tube.new(space, on_task_change, opts)
     return self
 end
 
+-- method.grant grants provided user to all spaces of driver.
+function method.grant(self, user, opts)
+    box.schema.user.grant(user, 'read,write', 'space', self.space.name, opts)
+    if self.space_ready_buffer ~= nil then
+        box.schema.user.grant(user, 'read,write', 'space', self.space_ready_buffer.name, opts)
+    end
+end
+
 -- normalize task: cleanup all internal fields
 function method.normalize_task(self, task)
     return task and task:transform(3, 1)

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -386,6 +386,14 @@ function tube.new(space, on_task_change, opts)
     return self
 end
 
+-- method.grant grants provided user to all spaces of driver.
+function method.grant(self, user, opts)
+    box.schema.user.grant(user, 'read,write', 'space', self.space.name, opts)
+    if self.space_ready_buffer ~= nil then
+        box.schema.user.grant(user, 'read,write', 'space', self.space_ready_buffer.name, opts)
+    end
+end
+
 -- cleanup internal fields in task
 function method.normalize_task(self, task)
     return task and task:transform(i_next_event, i_data - i_next_event)


### PR DESCRIPTION
There was a bug that grant for a user didn't work for spaces with `_ready_buffer` suffix.

After the patch the `grant` method was added for each driver that accounts the `grant` for all spaces.

Closes #237