### PR TITLE
core: failed to start if box.info.replication with gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Grant method was added for `*_ready_buffer` spaces (#237).
+- Attempt to index a nil value if box.info.replication array has gaps.
 
 ## [1.4.2] - 2024-08-10
 

--- a/queue/abstract/queue_state.lua
+++ b/queue/abstract/queue_state.lua
@@ -47,8 +47,9 @@ local function max_lag()
     local n_replica = table.maxn(box.info.replication)
 
     for i = 1, n_replica do
-        if box.info.replication[i].upstream then
-            local lag = box.info.replication[i].upstream.lag
+        local replica = box.info.replication[i]
+        if replica and replica.upstream then
+            local lag = replica.upstream.lag
             if lag > max_lag then
                 max_lag = lag
             end


### PR DESCRIPTION
The iterator does not handle the case where there are no records in the box.info.replication table in case of deleting old records, for examle:

```
- 1:
    id: 1
    uuid: 77f30d9a-d344-4f7a-a18c-578fb5ec2540
    lsn: 4
    name: null
  3:
    id: 3
    uuid: 0ce528ca-ea35-42be-96b5-35ba610f9a3e
    lsn: 0
    downstream:
      status: follow
      idle: 0.14953243732452
      vclock: {1: 4}
      lag: 0.0015106201171875
    name: null
```

It leads to the error and unable to start queue:

```
queue_state.lua:50: attempt to index a nil value
```