### PR TITLE
ci: bump actions to use ubuntu-24.04

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         # We need this step to run only on push with tag.
@@ -27,7 +27,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
     # Packaging for CentOS 7 does not work with other versions, see:
     # https://github.com/packpack/packpack/issues/145
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: version-check
 
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Clone the queue module'
         uses: actions/checkout@v4


### PR DESCRIPTION
Bump actions to use ubuntu-24.04 for fixing the following GitHub warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Part of #TNTP-1918