### PR TITLE
drivers: unable to take a task with utubettl

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -18,15 +18,15 @@ jobs:
       matrix:
         tarantool:
           - '1.10'
-          - '2.8'
-          - '2.10'
+          - '2.11'
+          - '3.4'
 
     steps:
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Incorrect choice by priority of task with utubettl driver + ready buffer
+  mode (#244).
+- Unable to take task with utubettl driver + ready buffer mode (#244).
+
 ## [1.4.3] - 2024-03-05
 
 The release fixes start of a queue on instances with gaps inside

--- a/queue/abstract/driver/utubettl.lua
+++ b/queue/abstract/driver/utubettl.lua
@@ -137,14 +137,17 @@ end
 local function put_ready(self, id, utube, pri)
     local taken = self.space.index.utube:min{state.TAKEN, utube}
     if taken == nil or taken[i_status] ~= state.TAKEN then
-        local current_task = self.space.index.utube_pri:min{state.READY, utube}
-        if current_task[i_status] ~= state.READY or
-                current_task[i_pri] < pri or (current_task[i_pri] == pri and current_task[i_id] < id) then
-            return
+        local cur_task = self.space_ready_buffer.index.utube:get{utube}
+
+        if cur_task ~= nil then
+            local cur_id = cur_task[1]
+            local cur_pri = cur_task[3]
+            if cur_pri < pri or (cur_pri == pri and cur_id < id) then
+                return
+            end
+            self.space_ready_buffer:delete(cur_id)
         end
-        if current_task[i_pri] > pri then
-            self.space_ready_buffer:delete(current_task[id])
-        end
+
         -- Ignoring ER_TUPLE_FOUND error, if a tuple with the same task_id
         -- or utube name is already in the space.
         -- Note that both task_id and utube indexes are unique, so there will be


### PR DESCRIPTION
Previously, the function incorrectly retrieved the lowest priority task instead of the actual task in the ready buffer. This caused a logical error when the current task had the lowest priority.

The implementation error caused:

1. Incorrect selection of the lowest priority task for a take.
2. ready buffer appearing empty when tasks were actually in ready state.