### PR TITLE
utubettl: commit transaction after on_task_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+## [1.4.5] - 2025-09-22
+
+Race condition between utubettl_fiber_iteration fiber and other operation.
+
+### Fixed
+
+- Erasing the task entry from _queue_taken_2 in the `utubettl` driver by
+  a race condition between utubettl_fiber_iteration fiber and other operation.
+
 ## [1.4.4] - 2025-05-26
 
 The patch release fixes incorrect behavior of the utubettl driver with enabled


### PR DESCRIPTION
Встретил такую ситуацию при использовании, фикс в данном мр: 

Файбер utubettl_fiber_iteration перевел задачу в статус R, сделав коммит, и в этот момент произошел свич контекст и пошел выполняться мой take из другого файбера, который взял задачу, обновил ее и даже записал инфу о take в _queue_taken_2, а уже после пришел в on_task_change файбер с delayed и удалил запись о взятой задаче. Как итог - задаче не может быть выполнен ack/release, так как не проходим проверку в функции check_task_is_taken.

Также исправил форматирование в логе на %s, так как при большом числе, которое не вмещается в number, будет ошибка.