### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.5.0] - 2026-07-10
+
+This release introduces tube-level grants for roles (supported by all default
+tube drivers). It also fixes `ERR_READONLY` errors on the previous leader
+when `on_disconnect` triggers run after a leadership change.
+
+### Added
+
 - Ability to grant tubes to roles. All default tube drivers are supported (#249).
   Example: `queue.tube.my_tube:grant_role('queue_worker', {call = true})`
-
-### Changed
 
 ### Fixed
 

--- a/queue/version.lua
+++ b/queue/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.4.4'
+return '1.5.0'


### PR DESCRIPTION
This release introduces tube-level grants for roles.
It also fixes `ERR_READONLY` errors after a leader change.

**Added**
- Ability to grant tubes to roles. Each user with this role will grant access to the tube.

**Fixed**
- `ERR_READONLY` errors on previous leader after a leader change: https://github.com/tarantool/queue/pull/252